### PR TITLE
Add basic ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Build book with docker container CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: build_pdfs_with_docker.sh
+      run: ./build_pdfs_with_docker.sh
+
+    - name: Archive PDFs
+      uses: actions/upload-artifact@v2
+      with:
+        name: PDFs
+        path: build/*.pdf


### PR DESCRIPTION
This builds the book's PDF using the docker image and stores the
produced PDF as a github action artefact, so it becomes easy to download
from the github UI when the CI job has run.

This depends on #13 
