### PR TITLE
Add ability to add items to index.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
+# SPDX-License-Identifier: CC-BY-4.0
+# SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
+
 PANDOCFLAGS = \
 	      --table-of-contents \
-	      --number-sections
+	      --number-sections \
+	      --standalone
 
-.PHONY: all
+.PHONY: all clean
 all: build/book.pdf
+clean:
+	rm -rf build
 
 build:
 	mkdir build
 
-build/book.pdf: book.md Makefile build
-	pandoc $< -o $@ $(PANDOCFLAGS)
+build/book.tex: book.md Makefile build
+	pandoc $< -t latex -o $@ $(PANDOCFLAGS)
+
+build/book.pdf: build/book.tex Makefile build
+	cd build && \
+	latexmk -pdf book.tex

--- a/book.md
+++ b/book.md
@@ -5,6 +5,12 @@ copyright:
 title: 'Low Level Software Security for Compiler Developers'
 documentclass: report
 papersize: A4
+header-includes:
+- |
+  ```{=latex}
+  \usepackage{makeidx}
+  \makeindex
+  ```
 ...
 
 # Introduction
@@ -94,3 +100,4 @@ feedback to be received through https://github.com/llsoftsec/llsoftsecbook.
 
 # Appendix: contribution guidelines
 
+\printindex

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN cd /root && \
 # 3. Add texlive binaries to PATH so they can be used easily.
 ENV PATH=/texlive/bin:$PATH
 # 4. install latex too (the minimal scheme selected above does not install latex)
-RUN tlmgr install latex latex-bin
+RUN tlmgr install latex latex-bin latexmk
 # 5. install extra latex packages needed for pandoc:
 RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr
 


### PR DESCRIPTION
This is based on latex makeindex functionality.
Adding a word to the index in the markdown text is as simply as
writing \index{word-to-add-to-index}.