### PR TITLE
Introduce the ability to add todos inline in the document

### DIFF
--- a/book.md
+++ b/book.md
@@ -10,6 +10,9 @@ header-includes:
   ```{=latex}
   \usepackage{makeidx}
   \makeindex
+  \usepackage[]{todonotes}
+  \let\oldtodo\todo
+  \renewcommand{\todo}[1]{\oldtodo{TODO: #1}}
   ```
 ...
 
@@ -101,3 +104,5 @@ feedback to be received through https://github.com/llsoftsec/llsoftsecbook.
 # Appendix: contribution guidelines
 
 \printindex
+
+\listoftodos

--- a/book.md
+++ b/book.md
@@ -10,10 +10,18 @@ header-includes:
   ```{=latex}
   \usepackage{makeidx}
   \makeindex
-  \usepackage[]{todonotes}
+  \newcounter{TodoCounter}
+  \usepackage[backgroundcolor=white,linecolor=black]{todonotes}
   \let\oldtodo\todo
-  \renewcommand{\todo}[1]{\oldtodo{TODO: #1}}
-  \newcommand{\missingcontent}[1]{\oldtodo[inline]{TODO: #1}}
+  \usepackage{bclogo}%  \bcpanchant
+  \renewcommand{\todo}[1]{
+    \stepcounter{TodoCounter}
+    \oldtodo[caption={\arabic{TodoCounter}. #1}]{\bcpanchant #1}
+  }
+  \newcommand{\missingcontent}[1]{
+    \stepcounter{TodoCounter}
+    \oldtodo[inline,caption={\arabic{TodoCounter}. #1}]{\bcpanchant \textit{#1}}
+  }
   ```
 ...
 

--- a/book.md
+++ b/book.md
@@ -13,6 +13,7 @@ header-includes:
   \usepackage[]{todonotes}
   \let\oldtodo\todo
   \renewcommand{\todo}[1]{\oldtodo{TODO: #1}}
+  \newcommand{\missingcontent}[1]{\oldtodo[inline]{TODO: #1}}
   ```
 ...
 
@@ -92,16 +93,32 @@ As a reader, you can also contribute to making this book better.  We highly
 encourage feedback, both positive and constructive criticisms.  We prefer
 feedback to be received through https://github.com/llsoftsec/llsoftsecbook.
 
-
+\missingcontent{Add section describing the structure of the rest of the book.}
+ 
 # Memory vulnerability based attacks and mitigations
+
+\missingcontent{Write chapter on memory vulnerabilities and mitigation.}
 
 # Physical access side channel attacks
 
+\missingcontent{Write chapter on physical access side channel attacks.}
+
 # Remote access side channel attacks
+
+\missingcontent{Write chapter on remote access side channel attacks.}
 
 # Other security topics relevant for compiler developers
 
+\missingcontent{Write chapter with other security topics.}
+
+\missingcontent{Write section on securely clearing memory in C/C++ and undefined behaviour.}
+
 # Appendix: contribution guidelines
+
+\missingcontent{Write chapter on contribution guidelines.
+ These should include at least: project locaton on github; how to create pull requests/issues.
+ Where do we discuss - mailing list? Grammar and writing style guidelines.
+ How to use todos and index.}
 
 \printindex
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,8 @@ ENV PATH=/texlive/bin:$PATH
 RUN tlmgr install latex latex-bin latexmk
 # 5. install extra latex packages needed for pandoc:
 RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr
+# 6. install extra packages needed for the book specifically:
+RUN tlmgr install todonotes epstopdf-pkg
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN tlmgr install latex latex-bin latexmk
 # 5. install extra latex packages needed for pandoc:
 RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr
 # 6. install extra packages needed for the book specifically:
-RUN tlmgr install todonotes epstopdf-pkg
+RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil pst-node mdframed zref needspace mptopdf
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The idea is that this makes it possible to develop content for the book using a similar trick as with software development where one sometimes writes "FIXME" or "TODO" comments to not get mentally stuck on a detail.
The hope is that having a simple way to jot down TODOs while writing content helps to make a note that more detail could be added to a section; while not holding up getting a section into review before that detail is added.