### PR TITLE
Automatically publish to github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build book with docker container CI
+name: Build
 
 on:
   push:
@@ -25,3 +25,12 @@ jobs:
           build/*.pdf
           build/*.html
           build/*.css
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      # Only publish the produced book when this was triggered on the main branch,
+      # and as part of a push (not as part of a pull request).
+      if: ${{ github.ref == 'refs/heads/main'  && github.event_name == 'push' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build

--- a/Makefile
+++ b/Makefile
@@ -9,20 +9,23 @@ PANDOCFLAGS = \
 .PHONY: all clean pdf html
 all: pdf html
 pdf: build/book.pdf
-html: build/book.html build/default.css
+html: build/book.html build/default.css build/index.html
 clean:
 	rm -rf build
 
 build:
 	mkdir build
 
-build/default.css: default.css Makefile
+build/default.css: default.css Makefile build
 	cp default.css build/default.css
 
 build/book.html: book.md book.bib Makefile build
 	pandoc $< -t html --filter pandoc-citeproc \
 		-M css=default.css \
 		-o $@ $(PANDOCFLAGS)
+
+build/index.html: build/book.html build
+	cp build/book.html build/index.html
 
 build/book.tex: book.md book.bib Makefile build
 	pandoc $< -t latex --filter pandoc-citeproc -o $@ $(PANDOCFLAGS)


### PR DESCRIPTION
This is done by running a github action step publishing the entire build
directory to the gh-pages branch. This only done for build actions that
are run on the main branch, and only when triggered by a push (and not
e.g. by a pull request).

One other minor addition is to make the book.html also available under
index.html, so that that's the page that gets picked up automatically on
the github pages webpage.