### PR TITLE
Add basic visitor counter to published HTML book page.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
           build/*.html
           build/*.css
 
+    - name: Prepare for publishing
+      run: ./.github/workflows/prepare_for_publishing.sh
+
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       # Only publish the produced book when this was triggered on the main branch,
@@ -33,7 +36,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main'  && github.event_name == 'push' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build
+        publish_dir: ./to_publish
 
   # Check links in markdown files.
   markdown-link-check:

--- a/.github/workflows/prepare_for_publishing.sh
+++ b/.github/workflows/prepare_for_publishing.sh
@@ -1,0 +1,6 @@
+# First copy build directory to to_publish directory
+cp -R build to_publish
+
+# Now add basic visitor counter to index.html, so that we can have a basic feel
+# for how often the page is watched.
+sed -i -e 's|</head>|<script data-goatcounter="https://llsoftsecbook.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script></head>|' to_publish/index.html


### PR DESCRIPTION
This adds a basic visitor counter to just the main index.html page published on https://llsoftsec.github.io/llsoftsecbook/.
The hope is that this will allow us to have at least some understanding of how many visitors there are reading the book online.

This uses the counter infrastructure at https://www.goatcounter.com/, which I hope is the most privacy-preserving freely available visitor counter service.