### PR TITLE
Git ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode


### PR DESCRIPTION
Developers using Visual Studio Code will have a .vscode directory in the clone
of the repository. Let git ignore it.