### PR TITLE
Automatically compute a version number.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: build
       run: ./build_with_docker.sh

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: CC-BY-4.0
 # SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
 
+version := $(shell git describe --match '0' --dirty="-with-local-changes")
 PANDOCFLAGS = \
 	      --table-of-contents \
 	      --number-sections \
 	      --standalone \
-	      --filter pandoc-citeproc
+	      --filter pandoc-citeproc \
+              --metadata=VERSION:$(version)
 
 .PHONY: all clean pdf html
 all: pdf html default_pandoc_html_template default_pandoc_latex_template
@@ -20,7 +22,7 @@ build:
 build/default.css: default.css Makefile build
 	cp default.css build/default.css
 
-build/book.html: book.md book.bib Makefile build
+build/book.html: book.md book.bib Makefile build pandoc_template.html
 	pandoc $< -t html \
 	    --template pandoc_template.html \
 		-M css=default.css \
@@ -29,7 +31,7 @@ build/book.html: book.md book.bib Makefile build
 build/index.html: build/book.html build
 	cp build/book.html build/index.html
 
-build/book.tex: book.md book.bib Makefile build
+build/book.tex: book.md book.bib Makefile build pandoc_template.tex
 	pandoc $< -t latex \
 		--template pandoc_template.tex \
 		-o $@ $(PANDOCFLAGS)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,10 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
 # 1. install pandoc and texlive dependencies
+#    Also install git as we need that for computing version numbers
 RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y wget perl pandoc make pandoc-citeproc && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+            wget perl pandoc make pandoc-citeproc git && \
     rm -rf /var/lib/apt/lists/*
 # 2. Install LaTeX directly from stable Texlive 2020 final repo
 # (We could alternatively install a base Texlive using "apt-get install

--- a/pandoc_template.html
+++ b/pandoc_template.html
@@ -65,6 +65,7 @@ $for(copyright)$
   $copyright.SPDX-FileCopyrightText$<br />
 $endfor$
 </p>
+<p>Version: $VERSION$</p>
 
 </header>
 $endif$

--- a/pandoc_template.tex
+++ b/pandoc_template.tex
@@ -370,6 +370,8 @@ Commons, PO Box 1866, Mountain View, CA 94042, USA.
 $for(copyright)$
   $copyright.SPDX-FileCopyrightText$\\
 $endfor$
+
+Version $VERSION$
 \clearpage
 
 $for(include-before)$


### PR DESCRIPTION
This automatically computes a version number from the book, using the "git
describe" command.
"git describe --match '0'" looks for the tag with name "0", and computes a
string following the following pattern:
"tag"-"nr of commits since that tag"-g"current commit hash".

By having a tag with name "0" pointing to the first commit of the project's
history, this produces a version string looking like
0-"nr of commits since initial commit"-g"current commit hash".
For example: 0-56-gcebad2f.

Using this as a version string has the following advantages:
- The version name starts with "0" suggesting the book isn't complete yet.
- Since we maintain a linear history in this project, the second number
  will be a nice linearly increasing number, allowing humans to quickly
  which of two versions is more recent than the other.
- The commit hash at the end unambiguously points to the source code
  revision the book was build from; which can be useful for project
  contributors.

By further more adding '--dirty="-with-local-changes"' to the git descirbe
command line, we make sure that if there are local changes in the git checkout
of the project at build time, this becomes visible by appending
"-with-local-changes" to the version number.