### PR TITLE
Make small/mobile screen view more readable

### DIFF
--- a/default.css
+++ b/default.css
@@ -17,3 +17,26 @@ body {
 body {
   font-family: sans-serif;
 }
+
+/* For smaller screens: */
+@media only screen and (max-width : 768px) {
+/* Put table-of-contents above paragraph elements. */
+#TOC {
+  position: relative;
+  left: 1%;
+  width: 94%;
+}
+/* Ensure superflous horizontal scroll bar is not added. */
+body {
+  text-align: left;
+  position: relative;
+  left: 1%;
+  width: 94%;
+  overflow-x: hidden;
+}
+/* Justify text for small-screen readability. */
+p {
+  text-align: justify;
+  text-justify: auto;
+}
+}


### PR DESCRIPTION
This commit addresses issue #32 by adding some basic 'responsive design' CSS to the default.css file such that the page layout is minimally adjusted when the viewport is less than 720px in width.

The effects of this change can be seen at:
https://jlouiskaplan-arm.github.io/llsoftsecbook/ 

(Note the changes only take effect with a viewport width of less than 720px.)

The main changes made for small screens are moving the contents above the paragraph elements and justifying paragraph text.

The advantage of the 'responsive design' approach is that changes made for small screens have no effect on the large screen styling.