### PR TITLE
Make build output belong to user who starts build

### DIFF
--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-readonly script_path="$0"
-readonly uid="$(stat -c "%u" "${script_path}")"
-readonly gid="$(stat -c "%g" "${script_path}")"
+readonly uid="$(id -u)"
+readonly gid="$(id -g)"
 docker build -t llsoftsecbook_build docker && docker run --rm --user="${uid}":"${gid}" --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,3 +1,1 @@
-build_args="--build-arg uname=${USER} --build-arg uid=$(id -u)"
-docker build $build_args -t llsoftsecbook_build docker
-docker run --rm --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all
+docker build -t llsoftsecbook_build docker && docker run --rm --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,4 +1,4 @@
-readonly base="$(dirname "${BASH_SOURCE[0]}")"
-readonly uid="$(stat -c "%u" $base)"
-readonly gid="$(stat -c "%g" $base)"
+readonly script_path="${BASH_SOURCE[0]}"
+readonly uid="$(stat -c "%u" $script_path)"
+readonly gid="$(stat -c "%g" $script_path)"
 docker build -t llsoftsecbook_build docker && docker run --rm --user=${uid}:${gid} --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,1 +1,4 @@
-docker build -t llsoftsecbook_build docker && docker run --rm --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all
+readonly base="$(dirname "${BASH_SOURCE[0]}")"
+readonly uid="$(stat -c "%u" $base)"
+readonly gid="$(stat -c "%g" $base)"
+docker build -t llsoftsecbook_build docker && docker run --rm --user=${uid}:${gid} --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,1 +1,3 @@
-docker build -t llsoftsecbook_build docker && docker run --rm --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all
+build_args="--build-arg uname=${USER} --build-arg uid=$(id -u)"
+docker build $build_args -t llsoftsecbook_build docker
+docker run --rm --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,4 +1,5 @@
-readonly script_path="${BASH_SOURCE[0]}"
-readonly uid="$(stat -c "%u" $script_path)"
-readonly gid="$(stat -c "%g" $script_path)"
-docker build -t llsoftsecbook_build docker && docker run --rm --user=${uid}:${gid} --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all
+#!/bin/sh
+readonly script_path="$0"
+readonly uid="$(stat -c "%u" "${script_path}")"
+readonly gid="$(stat -c "%g" "${script_path}")"
+docker build -t llsoftsecbook_build docker && docker run --rm --user="${uid}":"${gid}" --mount type=bind,source="$(pwd)",target=/src llsoftsecbook_build all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,12 @@
 # SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
+ARG uname
+ARG uid
+
+# 0. create in-container duplicate of user who started build
+RUN useradd -u $uid -s /bin/bash -m $uname
+
 # 1. install pandoc and texlive dependencies
 #    Also install git as we need that for computing version numbers
 RUN apt-get update && \
@@ -50,4 +56,5 @@ RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb bookt
 RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil pst-node mdframed zref needspace mptopdf
 
 COPY entrypoint.sh /entrypoint.sh
+USER $uname
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,12 +2,6 @@
 # SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
-ARG uname
-ARG uid
-
-# 0. create in-container duplicate of user who started build
-RUN useradd -u $uid -s /bin/bash -m $uname
-
 # 1. install pandoc and texlive dependencies
 #    Also install git as we need that for computing version numbers
 RUN apt-get update && \
@@ -56,5 +50,4 @@ RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb bookt
 RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil pst-node mdframed zref needspace mptopdf
 
 COPY entrypoint.sh /entrypoint.sh
-USER $uname
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
* Ensures that build output using
  the docker build script belongs
  to the user who triggered the build.

* Achieves this by adding a docker user
  with same uid and uname as the user who
  starts the docker build process and activates
  this user by default for the entrypoint.