### PR TITLE
Add suppport for pandoc-fignos filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PANDOCFLAGS = \
 	      --resource-path=. \
 	      --standalone \
 	      --self-contained \
+	      --filter pandoc-fignos \
 	      --filter pandoc-citeproc \
 	      --metadata=VERSION:$(version)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,13 +3,16 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
 # 1. install pandoc and texlive dependencies
-#    Also install git as we need that for computing version numbers
-#    Also install librsvg2-bin to enable pandoc to convert SVG images to PDF
+#    Also install git as we need that for computing version numbers.
+#    Also install librsvg2-bin to enable pandoc to convert SVG images to PDF.
+#    Also install python as the pandoc-fignos filter depends on it.
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y \
-            wget perl pandoc make pandoc-citeproc git librsvg2-bin && \
+            wget perl pandoc make pandoc-citeproc git librsvg2-bin python3-pip && \
     rm -rf /var/lib/apt/lists/*
-# 2. Install LaTeX directly from stable Texlive 2020 final repo
+# 2. Install pandoc-fignos filter
+RUN pip3 install pandoc-fignos
+# 3. Install LaTeX directly from stable Texlive 2020 final repo
 # (We could alternatively install a base Texlive using "apt-get install
 #  texlive-latex-extra", and then add extra packages using tlmgr.
 #  The drawbacks of that approach are:
@@ -41,12 +44,12 @@ RUN cd /root && \
         -profile texlive.profile \
         -repository https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2020/tlnet-final && \
     ln -s /texlive/2020/bin/* /texlive/bin
-# 3. Add texlive binaries to PATH so they can be used easily.
+# 4. Add texlive and pip3 binaries to PATH so they can be used easily.
 ENV PATH=/texlive/bin:$PATH
-# 4. install latex too (the minimal scheme selected above does not install latex)
+# 5. install latex too (the minimal scheme selected above does not install latex)
 RUN tlmgr install latex latex-bin latexmk
-# 5. install extra latex packages needed for pandoc:
-RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr grffile
+# 6. install extra latex packages needed for pandoc:
+RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr grffile cleveref caption
 # 6. install extra packages needed for the book specifically:
 RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil pst-node mdframed zref needspace mptopdf
 


### PR DESCRIPTION
This makes it possible to refer to figures from text.
See https://github.com/tomduck/pandoc-fignos for details.
This will be used by upcoming book content.