### PR TITLE
Use bootstrap for HTML output

### DIFF
--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -1,18 +1,5 @@
 /* Do not show bullet points for TOC entries: */
 #TOC ::marker { content: none; }
-/* Put the table-of-contents in 30%-ish wide left column. */
-#TOC {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 28%;
-}
-/* Put the main text in a 50%-ish wide column next to the TOC. */
-body {
-  position: relative;
-  left: 30%;
-  width: 50%;
-}
 /* Use a sans-serif font: */
 body {
   font-family: sans-serif;
@@ -36,27 +23,4 @@ h1:hover a, h1:active a,
 h2:hover a, h2:active a,
 h3:hover a, h2:active a {
   visibility: visible;
-}
-
-/* For smaller screens: */
-@media only screen and (max-width : 768px) {
-/* Put table-of-contents above paragraph elements. */
-#TOC {
-  position: relative;
-  left: 1%;
-  width: 94%;
-}
-/* Ensure superflous horizontal scroll bar is not added. */
-body {
-  text-align: left;
-  position: relative;
-  left: 1%;
-  width: 94%;
-  overflow-x: hidden;
-}
-/* Justify text for small-screen readability. */
-p {
-  text-align: justify;
-  text-justify: auto;
-}
 }

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -14,6 +14,15 @@ $if(keywords)$
   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
 $endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <link data-external="1" $-- data-external is needed to make sure pandoc does not
+                          $-- download and integrate the bootstrap CSS file. If it
+                          $-- would do so, it breaks bootstrap as the css refers to
+                          $-- other files too that pandoc does not download.
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65"
+    crossorigin="anonymous">
+</head>
   <style type="text/css">
       code{white-space: pre-wrap;}
       span.smallcaps{font-variant: small-caps;}
@@ -38,10 +47,20 @@ $for(header-includes)$
   $header-includes$
 $endfor$
 </head>
+
 <body>
 $for(include-before)$
 $include-before$
 $endfor$
+
+$-- This is the main bootstrap container into which all page content is placed
+$-- Class container-lg makes the container 100% wide if the viewport is a
+$-- smaller screen (less than 992px).
+<div class="container-lg">
+
+$-- The following row represents a screen-wide header. It contains the title,
+$-- copyright info etc.
+<div class="row">
 $if(title)$
 <header id="title-block-header">
 <h1 class="title">$title$</h1>
@@ -54,7 +73,6 @@ $endfor$
 $if(date)$
 <p class="date">$date$</p>
 $endif$
-
 <p>
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
   <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />
@@ -66,17 +84,42 @@ $for(copyright)$
 $endfor$
 </p>
 <p>Version: $VERSION$</p>
-
 </header>
 $endif$
+</div> $-- end of header row
+
+$-- start of the main "body" of the page
+$-- Containing TOC on left hand side and main content right hand side.
+<div class="row">
 $if(toc)$
+$--<div class="col-2 d-none d-md-block order-last sidebar">
+  $-- Bootstrap models the available width as "12 columns" wide
+  $-- Reserve 3 of those columns on the left hand side for the table of contents.
+  $-- The next 7 columns are reserved for the main content.
+  $-- Which leaves (12-3-7=2) columns for margin notes (not yet implemented).
+  $-- Note that with col-*md* we specify that we only want these columns to be
+  $-- next to each other if the viewport available is at least md = Medium = 768px
+  $-- (See any bootstrap guide/tutorial).
+<div class="col-md-3">
 <nav id="$idprefix$TOC">
 $table-of-contents$
 </nav>
+</div>
 $endif$
+
+$-- main content bootstrap "column"
+<main class="col-md-7" id="content">
 $body$
+</main>
+
+</div> $-- end of main bootstrap container.
+
 $for(include-after)$
 $include-after$
 $endfor$
+<script
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
+  crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
This is a first step towards moving to a much better HTML version of the book, see discussion in issue #32.

In this commit, the bare minimum has been done to recreate the existing layout with bootstrap. I've tried to add sufficient comments in the pandoc_template.html file so that it should be clear what each line does. I hope that will help with keeping the template file maintainable.

I see this is a first step on a longer road towards making a much nicer-looking HTML output, aiming for something similar to what Rust's mdbooks or bookdown.org books look like.

Note that by moving to bootstrap, the font seems to change a bit, and there is more spacing between lines. Not sure if we should consider trying to move back to the denser text from what we had before, or if we should stick with bootstrap's default.

Also, I made the "header" screen-wide. I.e., the left-hand side TOC does not appear at the top of the page, but under the header, i.e.  title, author, copyright info. We can change that back later if wanted.

Otherwise, I believe that the look-and-feel and functionality of the HTML output is the same as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/129)
<!-- Reviewable:end -->
