### PR TITLE
[HTML] Introduce title row with TOC button

### DIFF
--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -16,6 +16,13 @@ body {
   display: inline;
 }
 
+/* toc-sidebar needs some top-padding, otherwise the TOC starts too close to
+   the top bar. */
+#toc-sidebar
+{
+  padding-top: 2em;
+}
+
 /* No padding is needed on TOC top-level ul. Remove it so that we don't loose
    too much screen real-estate. */
 #toc-sidebar > ul {

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -22,6 +22,12 @@ body {
   display: none;
 }
 
+/* Remove underline from links in TOC. */
+#toc-sidebar a
+{
+  text-decoration: none;
+}
+
 /* Hide header link by default
    except on mouse hover, or
    click/tap (for mobile users) */

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -24,3 +24,15 @@ h2:hover a, h2:active a,
 h3:hover a, h2:active a {
   visibility: visible;
 }
+
+/* make the main content start under the fixed top navbar */
+body { padding-top: 70px; }
+/* when clicking a link, make sure that the link appears
+   below the navbar at the top, not at the same location as
+   the navbar at the top, which makes it hidden. */
+:target:before {
+  content:"";
+  display:block;
+  height:70px; /* fixed header height*/
+  margin:-70px 0 0; /* negative fixed header height */
+  }

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -1,15 +1,21 @@
 /* Do not show bullet points for TOC entries: */
-#TOC ::marker { content: none; }
+#toc-sidebar ::marker,
+#toc-modal ::marker
+{ content: none; }
 /* Use a sans-serif font: */
 body {
   font-family: sans-serif;
 }
 /* Don't show <span>s in TOC by default
    except if it's a section number. */
-#TOC a span {
+#toc-sidebar a span,
+#toc-modal a span
+{
   display: none;
 }
-#TOC a span.toc-section-number {
+#toc-sidebar a span.toc-section-number,
+#toc-modal a span.toc-section-number
+{
   display: inline;
 }
 /* Hide header link by default
@@ -25,14 +31,33 @@ h3:hover a, h2:active a {
   visibility: visible;
 }
 
-/* make the main content start under the fixed top navbar */
-body { padding-top: 70px; }
-/* when clicking a link, make sure that the link appears
-   below the navbar at the top, not at the same location as
-   the navbar at the top, which makes it hidden. */
-:target:before {
-  content:"";
-  display:block;
-  height:70px; /* fixed header height*/
-  margin:-70px 0 0; /* negative fixed header height */
-  }
+/* Set layout and size for top-level divs:
+  +-----------------------------------+
+  | body                              |
+  |+---------------------------------+|
+  ||   #top-bar                      ||
+  |+---------------------------------+|
+  ||   #all-below-top-bar            ||
+  ||+------------+------------------+||
+  |||#toc-sidebar| #main-content-col|||
+  ||+------------+------------------+||
+  |+-------------+-------------------+|
+  +-----------------------------------+
+
+   We're not using bootstrap for this top-level
+   layout (body, all-below-top-bar) because
+   it seems it does not support the necessary
+   "calc" height functionality needed for
+   #all-below-top-bar.
+
+   Within those containers, we do use bootstrap.
+*/
+
+body {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+#all-below-top-bar {
+  height: calc(100vh - 56px);
+}

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -1,6 +1,5 @@
 /* Do not show bullet points for TOC entries: */
-#toc-sidebar ::marker,
-#toc-modal ::marker
+#toc-sidebar ::marker
 { content: none; }
 /* Use a sans-serif font: */
 body {
@@ -8,20 +7,17 @@ body {
 }
 /* Don't show <span>s in TOC by default
    except if it's a section number. */
-#toc-sidebar a span,
-#toc-modal a span
+#toc-sidebar a span
 {
   display: none;
 }
-#toc-sidebar a span.toc-section-number,
-#toc-modal a span.toc-section-number
+#toc-sidebar a span.toc-section-number
 {
   display: inline;
 }
 
 /* only show TOC 2 levels deep: */
-#toc-sidebar ul ul ul,
-#toc-modal ul ul ul
+#toc-sidebar ul ul ul
 {
   display: none;
 }

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -69,3 +69,9 @@ body {
 #all-below-top-bar {
   height: calc(100vh - 56px);
 }
+
+/* Set maximum width so that lines do not get too long.
+   Lines of text that are too long are harder to read... */
+#main-content-col {
+  max-width: 768px; /* = bootstrap Medium/md */
+}

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -18,6 +18,14 @@ body {
 {
   display: inline;
 }
+
+/* only show TOC 2 levels deep: */
+#toc-sidebar ul ul ul,
+#toc-modal ul ul ul
+{
+  display: none;
+}
+
 /* Hide header link by default
    except on mouse hover, or
    click/tap (for mobile users) */

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -16,6 +16,12 @@ body {
   display: inline;
 }
 
+/* No padding is needed on TOC top-level ul. Remove it so that we don't loose
+   too much screen real-estate. */
+#toc-sidebar > ul {
+  padding: 0;
+}
+
 /* only show TOC 2 levels deep: */
 #toc-sidebar ul ul ul
 {

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -28,10 +28,12 @@ body {
   display: none;
 }
 
-/* Remove underline from links in TOC. */
+/* Remove underline from links in TOC.
+   Also make font size a bit smaller than the default content size. */
 #toc-sidebar a
 {
   text-decoration: none;
+  font-size: 0.875em;
 }
 
 /* Hide header link by default

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -89,6 +89,6 @@ body {
 
 /* Set maximum width so that lines do not get too long.
    Lines of text that are too long are harder to read... */
-#main-content-col {
+#main-content-max-width {
   max-width: 768px; /* = bootstrap Medium/md */
 }

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -76,6 +76,8 @@ $endif$
 
 $-- start of the "main" column
 <div id="main-content-col" class="h-100 col-12 col-lg-8 overflow-auto">
+  $-- max-width container for main content
+  <div id="main-content-max-width" class="h-100">
 $if(title)$
 <header id="title-block-header">
   <h1 class="title">$title$</h1>
@@ -107,8 +109,9 @@ $endif$
 <main id="content">
 $body$
 </main>
-</div> $-- row
-</div> $-- container
+</div> $-- max-width container for main content
+</div> $-- main-content-col
+</div> $-- container-fluid
 </div> $-- end of the "all-below-top-bar" column
 
 <script

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -55,7 +55,7 @@ $-- Implement the button row at the top of the screen.
   <div class="container-fluid">
     <button type="button"
       id="toggle-toc-button"
-      class="btn btn-primary">
+      class="btn btn-sm btn-outline-primary">
       <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="#">LlSoftSecBook</a>

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -83,7 +83,7 @@ $if(toc)$
 $endif$
 
 <div id="all-below-top-bar">
-  <div class="container h-100">
+  <div class="container-fluid h-100">
     <div class="row h-100 d-flex justify-content-between">
 $if(toc)$
   $-- show the TOC on the left hand side on lg screens and larger.

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -167,6 +167,10 @@ $body$
         reset_default_toc_visibility();
       }
     });
+
+    // Make links in the TOC be "secondary links". The result is that
+    // they will be coloured grey, so will be less distracting.
+    jQuery("#toc-sidebar a").addClass("link-secondary");
   });
 </script>
 

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -58,7 +58,7 @@ $-- Implement the button row at the top of the screen.
       class="btn btn-sm btn-outline-primary">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand" href="#">LlSoftSecBook</a>
+    <a class="navbar-brand" href="#">LLSoftSecBook</a>
   </div>
 </nav>
 

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -84,7 +84,7 @@ $endif$
 
 <div id="all-below-top-bar">
   <div class="container-fluid h-100">
-    <div class="row h-100 d-flex justify-content-between">
+    <div class="row h-100 d-flex justify-content-around">
 $if(toc)$
   $-- show the TOC on the left hand side on lg screens and larger.
   $-- d-none d-lg-block: makes the toc sidebar only visible on lg screens.

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -53,70 +53,80 @@ $for(include-before)$
 $include-before$
 $endfor$
 
-$-- This is the main bootstrap container into which all page content is placed
-$-- Class container-lg makes the container 100% wide if the viewport is a
-$-- smaller screen (less than 992px).
-<div class="container-lg">
+$-- This is the bootstrap container into which the top button row and TOC modal
+$-- is placed.
+<div class="container">
 
-$-- The following row represents a screen-wide header. It contains the title,
-$-- copyright info etc.
-<div class="row">
+$-- Implement the button row at the top of the screen.
+<nav class="navbar fixed-top navbar-light bg-light">
+  <div class="container">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal"
+    data-bs-target="#tocModal">
+      <span>TOC</span>
+    </button>
+    <a class="navbar-brand" href="#">LlSoftSecBook</a>
+  </div>
+</nav>
+
+$-- Show TOC as a "modal", when clicking the "TOC" button at the top left
+$if(toc)$
+  <div class="modal" id="tocModal" tabindex="-1" aria-labelledby="tocModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="tocModalLabel">Table of Contents</h5>
+          <button type="button"
+            class="btn-close" data-bs-dismiss="modal"
+            aria-label="Close"></button>
+        </div>
+        <div class="modal-body" id="TOC">
+          $table-of-contents$
+        </div>
+      </div>
+    </div>
+  </div>
+$endif$
+</div> $-- end of top navbar div with TOC modal
+
+$-- main content bootstrap container
+<main class="container" id="content">
+
 $if(title)$
 <header id="title-block-header">
-<h1 class="title">$title$</h1>
-$if(subtitle)$
-<p class="subtitle">$subtitle$</p>
-$endif$
-$for(author)$
-<p class="author">$author$</p>
-$endfor$
-$if(date)$
-<p class="date">$date$</p>
-$endif$
-<p>
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
-  <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />
-  This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-</p>
-<p>
-$for(copyright)$
-  $copyright.SPDX-FileCopyrightText$<br />
-$endfor$
-</p>
-<p>Version: $VERSION$</p>
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+    <p class="subtitle">$subtitle$</p>
+  $endif$
+  $for(author)$
+    <p class="author">$author$</p>
+  $endfor$
+  $if(date)$
+    <p class="date">$date$</p>
+  $endif$
+  <p>
+    <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+    <img alt="Creative Commons License" style="border-width:0"
+      src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+    This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+      Creative Commons Attribution 4.0 International License</a>.
+  </p>
+  <p>
+  $for(copyright)$
+    $copyright.SPDX-FileCopyrightText$<br />
+  $endfor$
+  </p>
+  <p>Version: $VERSION$</p>
 </header>
 $endif$
-</div> $-- end of header row
 
-$-- start of the main "body" of the page
-$-- Containing TOC on left hand side and main content right hand side.
-<div class="row">
-$if(toc)$
-$--<div class="col-2 d-none d-md-block order-last sidebar">
-  $-- Bootstrap models the available width as "12 columns" wide
-  $-- Reserve 3 of those columns on the left hand side for the table of contents.
-  $-- The next 7 columns are reserved for the main content.
-  $-- Which leaves (12-3-7=2) columns for margin notes (not yet implemented).
-  $-- Note that with col-*md* we specify that we only want these columns to be
-  $-- next to each other if the viewport available is at least md = Medium = 768px
-  $-- (See any bootstrap guide/tutorial).
-<div class="col-md-3">
-<nav id="$idprefix$TOC">
-$table-of-contents$
-</nav>
-</div>
-$endif$
-
-$-- main content bootstrap "column"
-<main class="col-md-7" id="content">
 $body$
-</main>
-
-</div> $-- end of main bootstrap container.
+</main> $-- end of main bootstrap container.
 
 $for(include-after)$
 $include-after$
 $endfor$
+
+
 <script
   src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -54,33 +54,13 @@ $-- Implement the button row at the top of the screen.
      class="navbar navbar-light bg-light">
   <div class="container-fluid">
     <button type="button"
-      class="btn btn-primary" data-bs-toggle="modal"
-      data-bs-target="#toc-modal">
+      id="toggle-toc-button"
+      class="btn btn-primary">
       <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="#">LlSoftSecBook</a>
   </div>
 </nav>
-
-$-- Show TOC as a "modal", when clicking the "TOC" button at the top left
-$if(toc)$
-  <div class="modal" id="toc-modal"
-    tabindex="-1" aria-labelledby="toc-modal-label" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="toc-modal-label">Table of Contents</h5>
-          <button type="button"
-            class="btn-close" data-bs-dismiss="modal"
-            aria-label="Close"></button>
-        </div>
-        <div class="modal-body" id="TOC">
-          $table-of-contents$
-        </div>
-      </div>
-    </div>
-  </div>
-$endif$
 
 <div id="all-below-top-bar">
   <div class="container-fluid h-100">
@@ -132,8 +112,64 @@ $body$
 </div> $-- end of the "all-below-top-bar" column
 
 <script
+  data-external="1"
+  src="https://code.jquery.com/jquery-3.6.3.min.js"
+  integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU="
+  crossorigin="anonymous"></script>
+<script
+  data-external="1"
   src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
   crossorigin="anonymous"></script>
+
+<script>
+  function isLG() {
+    var width = jQuery(window).width();
+    return width>=992;
+  }
+
+  jQuery(document).ready(function() {
+    // toggle sidebar-toc visibility when the toggle button is clicked.
+    jQuery('#toggle-toc-button').click(function() {
+      let toc_sidebar = jQuery('#toc-sidebar');
+      if (toc_sidebar.hasClass("d-lg-block")) {
+        // this is the first time the TOC toggler was clicked.
+        toc_sidebar.removeClass("d-lg-block");
+        // the screensize is smaller than lg -> make it the TOC visible.
+        // Otherwise, leave the d-none class to make the TOC invisible.
+        if (!isLG()) toc_sidebar.toggleClass("d-none");
+      } else {
+        toc_sidebar.toggleClass("d-none");
+      }
+    });
+
+    // When the window resizes across the LG (992 px) boundary, reset TOC
+    // visibility to the default, i.e. adding classes d-none and d-lg-block.
+    function reset_default_toc_visibility() {
+      let toc_sidebar = jQuery('#toc-sidebar');
+      toc_sidebar.addClass("d-none");
+      toc_sidebar.addClass("d-lg-block");
+    }
+
+    let previousWindowSizeWasLG = isLG();
+    jQuery(window).resize(function() {
+      let is_LG = isLG();
+      if (is_LG != previousWindowSizeWasLG) {
+        previousWindowSizeWasLG = is_LG;
+        reset_default_toc_visibility();
+      }
+    });
+
+    // Also make the TOC sidebar invisible after clicking a link in it
+    // when !isLG();
+    jQuery('#toc-sidebar a').click(function(){
+      if (!isLG()) {
+        reset_default_toc_visibility();
+      }
+    });
+  });
+</script>
+
 </body>
+
 </html>

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -129,13 +129,13 @@ $body$
   }
 
   jQuery(document).ready(function() {
-    // toggle sidebar-toc visibility when the toggle button is clicked.
+    // Toggle sidebar-toc visibility when the toggle button is clicked.
     jQuery('#toggle-toc-button').click(function() {
       let toc_sidebar = jQuery('#toc-sidebar');
       if (toc_sidebar.hasClass("d-lg-block")) {
-        // this is the first time the TOC toggler was clicked.
+        // This is the first time the TOC toggler was clicked.
         toc_sidebar.removeClass("d-lg-block");
-        // the screensize is smaller than lg -> make it the TOC visible.
+        // The screensize is smaller than lg -> make the TOC visible.
         // Otherwise, leave the d-none class to make the TOC invisible.
         if (!isLG()) toc_sidebar.toggleClass("d-none");
       } else {

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -49,20 +49,14 @@ $endfor$
 </head>
 
 <body>
-$for(include-before)$
-$include-before$
-$endfor$
-
-$-- This is the bootstrap container into which the top button row and TOC modal
-$-- is placed.
-<div class="container">
-
 $-- Implement the button row at the top of the screen.
-<nav class="navbar fixed-top navbar-light bg-light">
-  <div class="container">
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal"
-    data-bs-target="#tocModal">
-      <span>TOC</span>
+<nav id="top-bar"
+     class="navbar navbar-light bg-light">
+  <div class="container-fluid">
+    <button type="button"
+      class="btn btn-primary" data-bs-toggle="modal"
+      data-bs-target="#toc-modal">
+      <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="#">LlSoftSecBook</a>
   </div>
@@ -70,11 +64,12 @@ $-- Implement the button row at the top of the screen.
 
 $-- Show TOC as a "modal", when clicking the "TOC" button at the top left
 $if(toc)$
-  <div class="modal" id="tocModal" tabindex="-1" aria-labelledby="tocModalLabel" aria-hidden="true">
+  <div class="modal" id="toc-modal"
+    tabindex="-1" aria-labelledby="toc-modal-label" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="tocModalLabel">Table of Contents</h5>
+          <h5 class="modal-title" id="toc-modal-label">Table of Contents</h5>
           <button type="button"
             class="btn-close" data-bs-dismiss="modal"
             aria-label="Close"></button>
@@ -86,11 +81,21 @@ $if(toc)$
     </div>
   </div>
 $endif$
-</div> $-- end of top navbar div with TOC modal
 
-$-- main content bootstrap container
-<main class="container" id="content">
+<div id="all-below-top-bar">
+  <div class="container h-100">
+    <div class="row h-100 d-flex justify-content-between">
+$if(toc)$
+  $-- show the TOC on the left hand side on lg screens and larger.
+  $-- d-none d-lg-block: makes the toc sidebar only visible on lg screens.
+  $-- h-100 -> make div same height as parent div (#all-below-top-bar here)
+  <div id="toc-sidebar" class="h-100 d-none d-lg-block col-lg-4 overflow-auto">
+    $table-of-contents$
+  </div>
+$endif$
 
+$-- start of the "main" column
+<div id="main-content-col" class="h-100 col-12 col-lg-8 overflow-auto">
 $if(title)$
 <header id="title-block-header">
   <h1 class="title">$title$</h1>
@@ -119,13 +124,12 @@ $if(title)$
 </header>
 $endif$
 
+<main id="content">
 $body$
-</main> $-- end of main bootstrap container.
-
-$for(include-after)$
-$include-after$
-$endfor$
-
+</main>
+</div> $-- row
+</div> $-- container
+</div> $-- end of the "all-below-top-bar" column
 
 <script
   src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
For now, one button is introduced: TOC.
When clicked, it opens up a modal with the table of contents.

After experimenting with a number of different options on how to display the table of contents, it seemed best to me to just always leave it behind a button and a modal, so that independent of screen size it works the same.

I hope that labeling the button with "TOC" is intuitive enough for people to see that they have to click there to find the table of contents.

We could change this later for really large screens to still show a table-of-contents in a left-or-right hand column. I'm not sure at the moment if that will be best even for large-screen sizes at the moment, as I'd also like to have margin notes to display things such as footnotes, todos and maybe references/citations.

Let's improve the HTML look-and-feel incrementally. This seems like a useful step to commit.

commit-id:1b6fbf2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/135)
<!-- Reviewable:end -->
