### PR TITLE
[HTML] Fix scrollbar position on large screens

### DIFF
--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -132,26 +132,46 @@ $body$
   }
 
   jQuery(document).ready(function() {
+    let toc_sidebar = jQuery('#toc-sidebar');
+    let main_content_col = jQuery('#main-content-col');
+
+    function setTocVisibility(visible) {
+      if (visible) {
+        toc_sidebar.removeClass("d-none");
+        main_content_col.addClass("col-lg-8");
+        if (!isLG()) {
+          // on a small screen, make the main content invisible
+          // when the TOC is visible.
+          main_content_col.addClass("d-none");
+        }
+      } else {
+        toc_sidebar.addClass("d-none");
+        main_content_col.removeClass("col-lg-8");
+        main_content_col.removeClass("d-none");
+      }
+    }
+
     // Toggle sidebar-toc visibility when the toggle button is clicked.
     jQuery('#toggle-toc-button').click(function() {
-      let toc_sidebar = jQuery('#toc-sidebar');
       if (toc_sidebar.hasClass("d-lg-block")) {
         // This is the first time the TOC toggler was clicked.
         toc_sidebar.removeClass("d-lg-block");
         // The screensize is smaller than lg -> make the TOC visible.
         // Otherwise, leave the d-none class to make the TOC invisible.
-        if (!isLG()) toc_sidebar.toggleClass("d-none");
+        setTocVisibility(!isLG());
       } else {
-        toc_sidebar.toggleClass("d-none");
+        let isVisibleNow = !toc_sidebar.hasClass("d-none");
+        setTocVisibility(!isVisibleNow);
       }
     });
 
     // When the window resizes across the LG (992 px) boundary, reset TOC
     // visibility to the default, i.e. adding classes d-none and d-lg-block.
     function reset_default_toc_visibility() {
-      let toc_sidebar = jQuery('#toc-sidebar');
       toc_sidebar.addClass("d-none");
       toc_sidebar.addClass("d-lg-block");
+      main_content_col.addClass("col-lg-8");
+      main_content_col.removeClass("d-none");
     }
 
     let previousWindowSizeWasLG = isLG();


### PR DESCRIPTION
The main content pane has class col-lg-8 by default.  When the TOC sidebar is visible, which has col-lg-4, this nicely divides the screen between the 2 columns.
However, when the TOC is made invisible, that leaves screen space unused (only 8 of the 12 bootstrap columsn are used), resulting in a scrollbar not appearing at the right hand side, but maybe at 2/3ths of the screen.

Fix this by adding/removing the col-lg-8 class from the main content based on TOC visibility/invisibility.

This commit also fixes a second thing on small screens.  Before, when the TOC was made visible, the main content pane also remained visible, albeit below the TOC. This could lead to confusing views with 3 scrollbars, and just not looking good. Therefore, for small screens always show either the TOC or the main content.

The complexity of the javascript is getting to the point where I'm wondering if for the TOC/main column logic maybe we would be better of going full-custom and not use bootstrap at all. I'm not sure at the moment, so just kept sticking to using bootstrap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/136)
<!-- Reviewable:end -->
