### PR TITLE
[HTML] Add sidenotes, converted from footnotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,14 @@ build:
 build/default.css: theme/html/default.css Makefile build
 	cp theme/html/default.css build/default.css
 
-build/book.html: book.md book.bib Makefile build theme/html/pandoc_template.html theme/html/clickable_headers.lua build/default.css $(svgimages)
+build/book.html: book.md book.bib Makefile build theme/html/pandoc_template.html \
+                 theme/html/clickable_headers.lua \
+				 theme/html/convert_to_sidenote.lua \
+				 build/default.css $(svgimages)
 	pandoc $< -t html \
 		--template theme/html/pandoc_template.html \
 		--lua-filter theme/html/clickable_headers.lua \
+		--lua-filter theme/html/convert_to_sidenote.lua \
 		-M css=build/default.css \
 		--default-image-extension=svg \
 		-o $@ $(PANDOCFLAGS)

--- a/theme/html/convert_to_sidenote.lua
+++ b/theme/html/convert_to_sidenote.lua
@@ -1,14 +1,28 @@
 -- This lua pandoc filter converts footnotes to HTML "sidenote"s
 -- local logging = require 'theme/html/logging'
 
+sidenote_counter = 0;
+
 function Note (note)
   -- logging.temp('note', note)
-  -- Convert an Pandoc Node AST note to a <span class="sidenote"></span>
-  -- AST note.
-  -- A Note AST node has a "block" as content. A Span AST node needs an
-  -- "Inline" as content.
-  local span = pandoc.Span(pandoc.utils.blocks_to_inlines(note.content))
-  span.classes = {'sidenote'}
+  -- Convert a Pandoc Note AST node into AST nodes resembling:
+  --   <span class="sidenote_ref" href="#sidenote_xxx"><sup>ctr</sup></span>
+  --   <span id="sidenote_xxx" class="sidenote">ctr. xxx</span>
+  sidenote_counter = sidenote_counter + 1;
+  note_id = "sidenote_" .. sidenote_counter;
+  sidenote_content = {
+    pandoc.Str(sidenote_counter ..  ". "),
+    -- A Note AST node has a "block" as content. A Span AST node needs an
+    -- "Inline" as content.
+    table.unpack(pandoc.utils.blocks_to_inlines(note.content))};
+  local sidenote_span =
+    pandoc.Span(sidenote_content,
+                pandoc.Attr(note_id, {"sidenote"}, {}));
+  local sidenote_ref = pandoc.Span(
+    pandoc.RawInline(
+      "html",
+      "<sup>" .. sidenote_counter .. "</sup>"),
+      pandoc.Attr("", {"sidenote_ref"}, {href = "#" .. note_id}));
   -- logging.temp('span', span)
-  return span
+  return {sidenote_ref, sidenote_span}
 end

--- a/theme/html/convert_to_sidenote.lua
+++ b/theme/html/convert_to_sidenote.lua
@@ -1,0 +1,14 @@
+-- This lua pandoc filter converts footnotes to HTML "sidenote"s
+-- local logging = require 'theme/html/logging'
+
+function Note (note)
+  -- logging.temp('note', note)
+  -- Convert an Pandoc Node AST note to a <span class="sidenote"></span>
+  -- AST note.
+  -- A Note AST node has a "block" as content. A Span AST node needs an
+  -- "Inline" as content.
+  local span = pandoc.Span(pandoc.utils.blocks_to_inlines(note.content))
+  span.classes = {'sidenote'}
+  -- logging.temp('span', span)
+  return span
+end

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -110,9 +110,12 @@ body {
 .sidenote {
     display: inline; /* keep paragraphs with sidenote from breaking in 2. */
     float: right;    /* Show side notes on right hand side margin. */
-    width: 23vw;
-    margin-right: -25vw; /* pull the side note, next to the text, not in the
-                            main text. */
+
+    /* Limit the width of sidenotes on really large display to 376px. Otherwise
+       allow up to 23% of the screen width to be used by the sidenotes. */
+    width: calc(min(23vw, 376px));
+    /* pull the side note, next to the text, not in the main text. */
+    margin-right: calc(max(-25vw, -400px));
     font-size: 80%;  /* Make the font size of side notes somewhat smaller. */
 }
 
@@ -150,7 +153,7 @@ body {
     max-width: calc(min(25vw, 576px)); /* max 25% of screen */
   }
   #main-content-col:not(.without-tocsidebar) {
-    max-width: 75vw; /* TODO: how to make it exactly right width?, even when the toc-sidebar is collapsed? */
+    max-width: calc(100vw - min(25vw, 576px));
   }
   #main-content-col .without-tocsidebar {
     max-width: 100vw;

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -107,25 +107,30 @@ body {
 /* Set maximum width so that lines do not get too long.
    Lines of text that are too long are harder to read... */
 
+:root {
+  /* Limit the width of sidenotes on really large display to 376px. Otherwise
+     allow up to 23% of the screen width to be used by the sidenotes. */
+  --sidenote-width: calc(min(23vw, 376px));
+  --sidenote-col-width: calc(min(25vw, 400px)); /* including padding to main content. */
+}
+
 .sidenote {
     display: inline; /* keep paragraphs with sidenote from breaking in 2. */
     float: right;    /* Show side notes on right hand side margin. */
-
-    /* Limit the width of sidenotes on really large display to 376px. Otherwise
-       allow up to 23% of the screen width to be used by the sidenotes. */
-    width: calc(min(23vw, 376px));
+    width: var(--sidenote-width);
     /* pull the side note, next to the text, not in the main text. */
-    margin-right: calc(max(-25vw, -400px));
+    margin-right: calc(0px - var(--sidenote-col-width));
     font-size: 80%;  /* Make the font size of side notes somewhat smaller. */
 }
 
 /* xs and sm breakpoints: */
 @media (max-width: 767px) {
-  #toc-sidebar {
-    max-width: 100vw; /* on sizes where it only is visible as an overlay */
-  }
-  #main-content-max-width {
-    max-width: calc(min(100vw, 576px)); /* = bootstrap Medium/md */
+  :root {
+     /* on sizes where it only is visible as an overlay */
+    --toc-sidebar-max-width: 100vw;
+    --main-content-max-width: calc(min(100vw, 576px)); /* = bootstrap md */
+    /* sidenotes are shown inline on smalls screens. */
+    --sidenote-col-width: 0px;
   }
   /* show side bar content inline on small screens. */
   .sidenote {
@@ -139,26 +144,39 @@ body {
 
 /* md and lg breakpoints: */
 @media (min-width: 768px) {
-  #toc-sidebar {
-    max-width: 100vw; /* on sizes where it only is visible as an overlay */
-  }
-  #main-content-max-width {
-    max-width: calc(min(100vw, 576px)); /* = bootstrap Medium/md */
+  :root {
+    /* on sizes where it only is visible as an overlay */
+    --toc-sidebar-max-width: 100vw;
+    --main-content-max-width: calc(min(100vw, 576px)); /* = bootstrap md */
   }
 }
 
 /* xl and xxl breakpoints: */
 @media (min-width: 1200px) {
-  #toc-sidebar {
-    max-width: calc(min(25vw, 576px)); /* max 25% of screen */
+  :root {
+    /* on large displays, show TOC sidebar next to main text.
+       Make it 25% of screen width, but no more than 576px wide. */
+    --toc-sidebar-max-width: calc(min(25vw, 576px));
+    /* Make main content at most 75% of screen width to leave room for
+       the TOC sidebar, which is 25% width at most, see above.
+       576px limits the width to at most the bootstrap md breakpoint. */
+    --main-content-max-width: calc(min(75vw, 576px));
   }
   #main-content-col:not(.without-tocsidebar) {
-    max-width: calc(100vw - min(25vw, 576px));
+    max-width: calc(100vw - var(--toc-sidebar-max-width));
   }
   #main-content-col .without-tocsidebar {
     max-width: 100vw;
   }
-  #main-content-max-width {
-    max-width: calc(min(75vw, 576px)); /* = bootstrap Medium/md */
-  }
 }
+
+#toc-sidebar {
+  max-width: var(--toc-sidebar-max-width);
+}
+#main-content-max-width {
+  max-width: var(--main-content-max-width);
+}
+#main-content-with-sidenotes {
+  width: calc(var(--main-content-max-width) + var(--sidenote-col-width));
+}
+

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -57,17 +57,20 @@ h3:hover a, h2:active a {
 }
 
 /* Set layout and size for top-level divs:
-  +-----------------------------------+
-  | body                              |
-  |+---------------------------------+|
-  ||   #top-bar                      ||
-  |+---------------------------------+|
-  ||   #all-below-top-bar            ||
-  ||+------------+------------------+||
-  |||#toc-sidebar| #main-content-col|||
-  ||+------------+------------------+||
-  |+-------------+-------------------+|
-  +-----------------------------------+
+  +-------------------------------------------------------+
+  | body                                                  |
+  |+-----------------------------------------------------+|
+  ||   #top-bar                                          ||
+  |+-----------------------------------------------------+|
+  ||   #all-below-top-bar                                ||
+  ||+------------+--------------------------------------+||
+  |||#toc-sidebar|+------------------+-----------------+|||
+  |||            ||#main-content-col | sidenotescol    ||||
+  |||            ||                  |                 ||||
+  |||            |+------------------+-----------------+|||
+  ||+------------+--------------------------------------+||
+  |+-------------+---------------------------------------+|
+  +-------------------------------------------------------+
 
    We're not using bootstrap for this top-level
    layout (body, all-below-top-bar) because
@@ -76,6 +79,20 @@ h3:hover a, h2:active a {
    #all-below-top-bar.
 
    Within those containers, we do use bootstrap.
+*/
+
+/* bootstrap breakpoints:
+   xs < 576px <= sm < 768px <= md < 992px <= lg < 1200px <= xl < 1400px <= xxl
+
+   On the different screen sizes we make the different content columns visible
+   by default as follows:
+
+   * xs and sm: only the main content column. sidenotes are shown inline.
+   * md and lg: only the main content column and the sidenotes column are shown
+     max-width(main)=min(75% width, md); max-width(sidenotes)=min(25% width, xs?)
+   * xl, xxl: toc, main content and the sidenotes are shown.
+     max-width(main)=min(50% width, md);
+     max-width(sidenotes) and max-width(toc)=min(25% width, xs?)
 */
 
 body {
@@ -89,6 +106,56 @@ body {
 
 /* Set maximum width so that lines do not get too long.
    Lines of text that are too long are harder to read... */
-#main-content-max-width {
-  max-width: 768px; /* = bootstrap Medium/md */
+
+.sidenote {
+    display: inline; /* keep paragraphs with sidenote from breaking in 2. */
+    float: right;    /* Show side notes on right hand side margin. */
+    width: 23vw;
+    margin-right: -25vw; /* pull the side note, next to the text, not in the
+                            main text. */
+    font-size: 80%;  /* Make the font size of side notes somewhat smaller. */
+}
+
+/* xs and sm breakpoints: */
+@media (max-width: 767px) {
+  #toc-sidebar {
+    max-width: 100vw; /* on sizes where it only is visible as an overlay */
+  }
+  #main-content-max-width {
+    max-width: calc(min(100vw, 576px)); /* = bootstrap Medium/md */
+  }
+  /* show side bar content inline on small screens. */
+  .sidenote {
+    display: block; 	/* forces parent paragraph to break */
+    float: none; 	/* stops content from floating */
+    margin: 5% 10% 5% 10%;
+    width: 80%;
+    font-size: 80%;
+  }
+}
+
+/* md and lg breakpoints: */
+@media (min-width: 768px) {
+  #toc-sidebar {
+    max-width: 100vw; /* on sizes where it only is visible as an overlay */
+  }
+  #main-content-max-width {
+    max-width: calc(min(100vw, 576px)); /* = bootstrap Medium/md */
+  }
+}
+
+/* xl and xxl breakpoints: */
+@media (min-width: 1200px) {
+  #toc-sidebar {
+    max-width: calc(min(25vw, 576px)); /* max 25% of screen */
+  }
+  #main-content-col:not(.without-tocsidebar) {
+    max-width: 75vw; /* TODO: how to make it exactly right width?, even when the toc-sidebar is collapsed? */
+  }
+  #main-content-col .without-tocsidebar {
+    max-width: 100vw;
+  }
+  #main-content-max-width {
+    max-width: calc(min(75vw, 576px)); /* = bootstrap Medium/md */
+  }
 }

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -115,7 +115,6 @@ body {
 }
 
 .sidenote {
-    display: inline; /* keep paragraphs with sidenote from breaking in 2. */
     float: right;    /* Show side notes on right hand side margin. */
     width: var(--sidenote-width);
     /* pull the side note, next to the text, not in the main text. */
@@ -134,7 +133,8 @@ body {
   }
   /* show side bar content inline on small screens. */
   .sidenote {
-    display: block; 	/* forces parent paragraph to break */
+    display: none; 	/* don't show sidenotes by default on small
+                       screens where they appear inline. */
     float: none; 	/* stops content from floating */
     margin: 5% 10% 5% 10%;
     width: 80%;
@@ -180,3 +180,6 @@ body {
   width: calc(var(--main-content-max-width) + var(--sidenote-col-width));
 }
 
+.sidenote_ref {
+  cursor: pointer;
+}

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -90,7 +90,8 @@ $if(toc)$
 $endif$
 
 $-- start of the "main" column
-<div id="main-content-col" class="h-100 overflow-auto">
+<div id="main-content-col" class="h-100  d-flex justify-content-center overflow-auto">
+  <div id="main-content-with-sidenotes" class="h-100">
   $-- max-width container for main content
   <div id="main-content-max-width" class="h-100">
 $if(title)$
@@ -125,6 +126,7 @@ $endif$
 $body$
 </main>
 </div> $-- max-width container for main content
+</div> $-- main-content-with-sidenotes
 </div> $-- main-content-col
 </div> $-- container-fluid
 </div> $-- end of the "all-below-top-bar" column

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -81,16 +81,16 @@ $-- Implement the button row at the top of the screen.
   <div class="container-fluid h-100">
     <div class="row h-100 d-flex justify-content-around">
 $if(toc)$
-  $-- show the TOC on the left hand side on lg screens and larger.
-  $-- d-none d-lg-block: makes the toc sidebar only visible on lg screens.
+  $-- show the TOC on the left hand side on xl screens and larger.
+  $-- d-none d-xl-block: makes the toc sidebar only visible on xl screens.
   $-- h-100 -> make div same height as parent div (#all-below-top-bar here)
-  <div id="toc-sidebar" class="h-100 d-none d-lg-block col-lg-4 overflow-auto">
+  <div id="toc-sidebar" class="h-100 d-none d-xl-block overflow-auto">
     $table-of-contents$
   </div>
 $endif$
 
 $-- start of the "main" column
-<div id="main-content-col" class="h-100 col-12 col-lg-8 overflow-auto">
+<div id="main-content-col" class="h-100 overflow-auto">
   $-- max-width container for main content
   <div id="main-content-max-width" class="h-100">
 $if(title)$
@@ -144,9 +144,9 @@ $body$
   src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"/>
 
 <script>
-  function isLG() {
+  function isXL() {
     var width = jQuery(window).width();
-    return width>=992;
+    return width>=1200;
   }
 
   jQuery(document).ready(function() {
@@ -156,8 +156,8 @@ $body$
     function setTocVisibility(visible) {
       if (visible) {
         toc_sidebar.removeClass("d-none");
-        main_content_col.addClass("col-lg-8");
-        if (!isLG()) {
+        main_content_col.removeClass("without-tocsidebar");
+        if (!isXL()) {
           // on a small screen, make the main content invisible
           // when the TOC is visible.
           main_content_col.addClass("d-none");
@@ -167,47 +167,47 @@ $body$
         // when the TOC is not visible, make the main container span the full
         // width of the screen. This makes sure that the scrollbar appears on
         // the far right hand side.
-        main_content_col.removeClass("col-lg-8");
         main_content_col.removeClass("d-none");
+        main_content_col.addClass("without-tocsidebar");
       }
     }
 
     // Toggle sidebar-toc visibility when the toggle button is clicked.
     jQuery('#toggle-toc-button').click(function() {
-      if (toc_sidebar.hasClass("d-lg-block")) {
+      if (toc_sidebar.hasClass("d-xl-block")) {
         // This is the first time the TOC toggler was clicked.
-        toc_sidebar.removeClass("d-lg-block");
-        // The screensize is smaller than lg -> make the TOC visible.
+        toc_sidebar.removeClass("d-xl-block");
+        // The screensize is smaller than xl -> make the TOC visible.
         // Otherwise, leave the d-none class to make the TOC invisible.
-        setTocVisibility(!isLG());
+        setTocVisibility(!isXL());
       } else {
         let isVisibleNow = !toc_sidebar.hasClass("d-none");
         setTocVisibility(!isVisibleNow);
       }
     });
 
-    // When the window resizes across the LG (992 px) boundary, reset TOC
-    // visibility to the default, i.e. adding classes d-none and d-lg-block.
+    // When the window resizes across the XL boundary, reset TOC
+    // visibility to the default, i.e. adding classes d-none and d-xl-block.
     function reset_default_toc_visibility() {
       toc_sidebar.addClass("d-none");
-      toc_sidebar.addClass("d-lg-block");
-      main_content_col.addClass("col-lg-8");
+      toc_sidebar.addClass("d-xl-block");
       main_content_col.removeClass("d-none");
+      main_content_col.removeClass("without-tocsidebar");
     }
 
-    let previousWindowSizeWasLG = isLG();
+    let previousWindowSizeWasXL = isXL();
     jQuery(window).resize(function() {
-      let is_LG = isLG();
-      if (is_LG != previousWindowSizeWasLG) {
-        previousWindowSizeWasLG = is_LG;
+      let is_XL = isXL();
+      if (is_XL != previousWindowSizeWasXL) {
+        previousWindowSizeWasXL = is_XL;
         reset_default_toc_visibility();
       }
     });
 
     // Also make the TOC sidebar invisible after clicking a link in it
-    // when !isLG();
+    // when !iXL();
     jQuery('#toc-sidebar a').click(function(){
-      if (!isLG()) {
+      if (!isXL()) {
         reset_default_toc_visibility();
       }
     });

--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -222,6 +222,17 @@ $body$
     let tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     let tooltipList = [...tooltipTriggerList].map(
       tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl, {trigger : 'hover'}));
+
+    // Make sidenotes toggleable:
+    jQuery('.sidenote_ref').click(function(){
+      let sidenote_id = jQuery(this).attr("href");
+      let sidenote = jQuery(sidenote_id);
+      if (sidenote.css("display") == "none") {
+        sidenote.css("display", "block");
+      } else {
+        sidenote.css("display", "none");
+      }
+    });
   });
 </script>
 


### PR DESCRIPTION
This change adds a sidenotes margin on the right hand side. It puts the footnotes in the right hand margin rather than at the bottom of the document.

To make space for the sidenote marging, the TOC on the left hand side only gets shown by default on xl screens.

To implement this required doing more things outside of the bootstrap framework. As a result, we don't use the bootstrap framework for sizing "columns" anymore. We still do use other features of the bootstrap framework.

On smaller screens, the "sidenotes" get displayed inline, i.e. there is a responsive design for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/139)
<!-- Reviewable:end -->
