### PR TITLE
[HTML] Show \todo and \missingcontent as sidenote.

### DIFF
--- a/theme/html/convert_to_sidenote.lua
+++ b/theme/html/convert_to_sidenote.lua
@@ -26,3 +26,76 @@ function Note (note)
   -- logging.temp('span', span)
   return {sidenote_ref, sidenote_span}
 end
+
+-- convert \todo's and \missingcontent's to HTML sidenotes
+-- They can appear as both RawBlock or RawInlines.
+
+todo_counter = 0;
+missingcontent_counter = 0;
+
+function get_raw_text(raw_content)
+  -- logging.temp('seeing rawblock/rawinline', raw_content);
+  if string.find(raw_content, "^\\todo{") then
+    todo_counter = todo_counter + 1;
+    note_id = "todo_" .. todo_counter;
+    keyword_length = string.len("\\todo{");
+    sidenote_class = "todo"
+    assert(string.find(raw_content, "}$"),
+           "\\todo doesn't end with '}'");
+  else if string.find(raw_content, "^\\missingcontent{") then
+      missingcontent_counter = missingcontent_counter + 1;
+      note_id = "missingcontent_" .. missingcontent_counter;
+      keyword_length = string.len("\\missingcontent{");
+      sidenote_class = "missingcontent"
+      assert(string.find(raw_content, "}$"),
+             "\\missingcontent doesn't end with '}'");
+    else
+      return nil;
+    end
+  end
+  local len = string.len(raw_content);
+  -- strip of '\\todo{' and '}'
+  local content = string.sub(raw_content, keyword_length+1, len-1);
+  -- logging.temp('recognized ' .. sidenote_class .. ': ' .. content);
+  return sidenote_class, note_id, content;
+end
+
+function create_spans(sidenote_class, note_id, content, isblock)
+  local sidenote_span =
+    pandoc.Span(pandoc.Str(content),
+                pandoc.Attr(note_id, {sidenote_class}, {}));
+  local sidenote_ref =
+    pandoc.Span(
+      pandoc.RawInline("html", "<sup>" .. sidenote_class .. "</sup>"),
+      pandoc.Attr("", {sidenote_class .. "_ref"}, {href = "#" .. note_id}));
+  if isblock then
+    sidenote_span = pandoc.Plain(sidenote_span);
+    sidenote_ref = pandoc.Plain(sidenote_ref);
+  end
+  return {sidenote_ref, sidenote_span}
+end
+
+
+function RawInline (rawinline)
+  if not rawinline.format == 'tex' then
+    return rawinline;
+  end
+  sidenote_class, note_id, rawcontent = get_raw_text(rawinline.text);
+  if sidenote_class == nil then
+    return rawblock;
+  end
+  return create_spans(sidenote_class, note_id, rawcontent, false);
+end
+
+function RawBlock (rawblock)
+  -- convert \todo's to HTML sidenotes.
+  -- \todo's are present as rawblocks for format tex.
+  if not rawblock.format == 'tex' then
+    return rawblock;
+  end
+  sidenote_class, note_id, content = get_raw_text(rawblock.text);
+  if sidenote_class == nil then
+    return rawblock;
+  end
+  return create_spans(sidenote_class, note_id, content, true);
+end

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -114,13 +114,38 @@ body {
   --sidenote-col-width: calc(min(25vw, 400px)); /* including padding to main content. */
 }
 
-.sidenote {
+.sidenote, .todo, .missingcontent {
     float: right;    /* Show side notes on right hand side margin. */
+    clear: right;    /* if multiple notes would overlap, push them below each
+                        other. */
+    margin-bottom: 1em; /* leave a bit of margin between sidenotes. */
     width: var(--sidenote-width);
     /* pull the side note, next to the text, not in the main text. */
     margin-right: calc(0px - var(--sidenote-col-width));
     font-size: 80%;  /* Make the font size of side notes somewhat smaller. */
 }
+
+.todo, .missingcontent {
+  color: gray;
+  font-style: italic;
+}
+
+.todo::before {
+  font-weight: bold;
+  color: navy;
+  content: "Todo ";
+}
+
+.missingcontent::before {
+  font-weight: bold;
+  color: navy;
+  content: "Missing content ";
+}
+
+.todo_ref, .missingcontent_ref {
+  display: none;
+}
+
 
 /* xs and sm breakpoints: */
 @media (max-width: 767px) {
@@ -132,7 +157,7 @@ body {
     --sidenote-col-width: 0px;
   }
   /* show side bar content inline on small screens. */
-  .sidenote {
+  .sidenote, .todo, .missingcontent {
     display: none; 	/* don't show sidenotes by default on small
                        screens where they appear inline. */
     float: none; 	/* stops content from floating */


### PR DESCRIPTION
This shows todo's and missing contents as side notes in the HTML output.

For small screens, where sidenotes are shown inline, this commit does not show the todos or missingcontents at all. It could be chosen later to have an indication (small button?) that the reader could click to make todos/missingcontent info visible.

We could also implement a button in the top row to toggle visibility of todos/missingcontent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/140)
<!-- Reviewable:end -->
