### PR TITLE
[HTML] Make tooltips appear on the bottom of buttons

### DIFF
--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -56,19 +56,22 @@ $-- Implement the button row at the top of the screen.
      class="navbar navbar-light bg-light">
   <div class="container-fluid">
     <div> $-- div is needed to keep the buttons in it next to each other.
-    <button type="button"
+    <a role="button"
       id="toggle-toc-button"
       class="btn btn-sm btn-outline-primary"
-      data-bs-toggle="tooltip" data-bs-title="Toggle table-of-contents">
+      data-bs-toggle="tooltip" data-bs-title="Toggle table-of-contents"
+      data-bs-placement="bottom">
       <span class="navbar-toggler-icon"></span>
-    </button>
+    </a>
     <a id="view-source-button"
       class="btn btn-sm btn-outline-primary" role="button"
+      data-bs-placement="bottom"
       data-bs-toggle="tooltip" data-bs-title="Github repo"
       href="$github-repo$">
       <i class="bi bi-github"></i></a>
     <a id="view-source-button"
       class="btn btn-sm btn-outline-primary" role="button"
+      data-bs-placement="bottom"
       data-bs-toggle="tooltip" data-bs-title="Suggest an edit"
       href="$github-edit-link$">
       <i class="bi bi-pen"></i></a>


### PR DESCRIPTION
... rather than to the left, so that a tooltip is less likely to hide other buttons.

However, for this first button ("toggle TOC"), this does not seem to be working: the tooltip continues to be shown on the right hand side, i.e. over the other buttons.

I could not find a way to change the behaviour.
Overall, this still is an improvement for the other buttons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/141)
<!-- Reviewable:end -->
