### PR TITLE
[HTML] Do not show tooltips on touch screen devices.

### DIFF
--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -222,9 +222,14 @@ $body$
     jQuery("#toc-sidebar a").addClass("link-secondary");
 
     // Needed to enable the bootstrap tooltips:
-    let tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-    let tooltipList = [...tooltipTriggerList].map(
-      tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl, {trigger : 'hover'}));
+    let isTouchScreen = "ontouchstart" in document.documentElement;
+    if (!isTouchScreen) {
+      let tooltipTriggerList =
+        document.querySelectorAll('[data-bs-toggle="tooltip"]');
+      let tooltipList = [...tooltipTriggerList].map(
+        tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl,
+                                                  {trigger : 'hover'}));
+    }
 
     // Make sidenotes toggleable:
     jQuery('.sidenote_ref').click(function(){


### PR DESCRIPTION
On touch screen devices, the tooltips are not really useful. They only pop up after the user already pushes the button, so they are then already "activating" the button action.

Therefore, disable them on touch devices.
The most consistent advice when looking for how to do that seems to be to use "ontouchstart" in document.DocumentElement. At least in Firefox this seems to work as expect across desktop and mobile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/144)
<!-- Reviewable:end -->
