### PR TITLE
[HTML] only show section symbol for h4 on hover

### DIFF
--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -46,13 +46,14 @@ body {
 /* Hide header link by default
    except on mouse hover, or
    click/tap (for mobile users) */
-h1 a, h2 a, h3 a {
+h1 a, h2 a, h3 a, h4 a {
   visibility: hidden;
   font-size: 85%;
 }
 h1:hover a, h1:active a,
 h2:hover a, h2:active a,
-h3:hover a, h2:active a {
+h3:hover a, h3:active a,
+h4:hover a, h4:active a {
   visibility: visible;
 }
 

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -46,14 +46,16 @@ body {
 /* Hide header link by default
    except on mouse hover, or
    click/tap (for mobile users) */
-h1 a, h2 a, h3 a, h4 a {
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
   visibility: hidden;
   font-size: 85%;
 }
 h1:hover a, h1:active a,
 h2:hover a, h2:active a,
 h3:hover a, h3:active a,
-h4:hover a, h4:active a {
+h4:hover a, h4:active a,
+h5:hover a, h5:active a,
+h6:hover a, h6:active a {
   visibility: visible;
 }
 


### PR DESCRIPTION
Section symbol was always present for h4 elements, which is inconsistent with behaviour for other h* elements.

This patch makes h4 behaviour consistent with h1-3 by making the section symbol appear only when mouse is hovered over an h4 element.

Fixes #147

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/148)
<!-- Reviewable:end -->
