### PR TITLE
Add chapter about compiler introduced security vulns

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -500,3 +500,74 @@ publisher = {Addison-Wesley Professional},
   booktitle = {NDSS},
   year      = {2015}
 }
+
+@inproceedings{wang2012undefined,
+  title={Undefined behavior: what happened to my code?},
+  author={Wang, Xi and Chen, Haogang and Cheung, Alvin and Jia, Zhihao and Zeldovich, Nickolai and Kaashoek, M Frans},
+  booktitle={Proceedings of the Asia-Pacific Workshop on Systems},
+  pages={1--7},
+  year={2012}
+}
+
+@inproceedings{d2015correctness,
+  title={The correctness-security gap in compiler optimization},
+  author={D'Silva, Vijay and Payer, Mathias and Song, Dawn},
+  booktitle={2015 IEEE Security and Privacy Workshops},
+  pages={73--87},
+  year={2015},
+  organization={IEEE}
+}
+
+@article{dusilent,
+  title={Silent Bugs Matter: A Study of Compiler-Introduced Security Bugs},
+  author={Du, Jianhao Xu1 Kangjie Lu2 Zhengjie and Wu, Zhu Ding1 Linke Li1 Qiushi and Mao, Mathias Payer3 Bing}
+}
+
+@Electronic{Wang2015,
+  author = {Xi Wang},
+  title  = {More randomness or less},
+  url    = {https://kqueue.org/blog/2012/06/25/more-randomness-or-less/},
+  year   = {2015},
+}
+
+@Electronic{FbsdJunk,
+  title  = {FreeBSD mitigation for srandom undefined behavior},
+  url    = {https://github.com/freebsd/freebsd-src/commit/6a762eb23ea5f31e65cfa12602937f39a14e9b0c},
+  year   = {2012},
+}
+
+@Electronic{ObsdJunk,
+  title  = {OpenBSD mitigation for srandom undefined behavior},
+  url    = {https://github.com/openbsd/src/commit/99d815f892ce481695caf21f08f773f563820a66},
+  year   = {2002},
+}
+
+@Electronic{ChromiumIssue,
+  title  = {Issue 3782: V8 is not -fsanitize=null clean},
+  url    = {https://bugs.chromium.org/p/v8/issues/detail?id=3782},
+  year   = {2014},
+}
+
+@Electronic{MozillaIssue,
+  title  = {GCC6 - TB crashes due to removed null pointer checks for "this"},
+  url    = {https://bugzilla.mozilla.org/show_bug.cgi?id=1251576},
+  year   = {2016},
+}
+
+@Electronic{MemZeroBarrier,
+  title  = {lib: memzero_explicit: use barrier instead of OPTIMIZER_HIDE_VAR},
+  url    = {https://github.com/torvalds/linux/commit/0b053c9518292705736329a8fe20ef4686ffc8e9},
+  year   = {2015},
+}
+
+@Electronic{MemZeroDataBarrier,
+  title  = {lib: make memzero_explicit more robust against dead store elimination},
+  url    = {https://github.com/torvalds/linux/commit/7829fb09a2b4268b30dd9bc782fa5ebee278b137},
+  year   = {2015},
+}
+
+@Electronic{OpenSSLMemClr,
+  title  = {lib: make memzero_explicit more robust against dead store elimination},
+  url    = {https://github.com/openssl/openssl/commit/104ce8a9f02d250dd43c255eb7b8747e81b29422},
+  year   = {2016},
+}

--- a/book.bib
+++ b/book.bib
@@ -571,3 +571,14 @@ publisher = {Addison-Wesley Professional},
   url    = {https://github.com/openssl/openssl/commit/104ce8a9f02d250dd43c255eb7b8747e81b29422},
   year   = {2016},
 }
+
+@Electronic{GNUMemSet,
+  title  = {10.604 memset_explicit},
+  url    = {https://www.gnu.org/software//gnulib/manual/html_node/memset_005fexplicit.html},
+}
+
+@Electronic{MemSetProposal,
+  title  = {memset_explicit},
+  url    = {https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2897.htm},
+  year   = {2021},
+}

--- a/book.md
+++ b/book.md
@@ -1961,6 +1961,188 @@ Explain how these vulnerabilities arise and how to mitigate them.
 [180]{.issue}
 :::
 
+# Compiler introduced security vulnerabilities
+
+Security vulnerabilities introduced by compilers have a long history.  Thompson
+[@Thompson1984] provides one of the oldest and most popular example in this
+area. In his paper, he talks about a compiler that can detect when it is
+compiling the login program and can insert a backdoor so that he can use the
+system as any user.  However most common cases are where involuntary security
+vulnerabilities are added in the generated binary by the compiler.
+
+When discussing about compiler introduced security vulnerabilities,
+undefined behavior plays a major role. Its implications were throughfully
+discussed by various works such as [@wang2012undefined, @d2015correctness,
+@dusilent]. By reading the works of these authors, one can see that even
+projects that went through careful testing, such as Linux, FreeBSD or
+PostgreSQL, could not escape from this class of vulnerabilities. To better
+understand them, this chapter will contain several examples of such
+vulnerabilities, their implications and how they got fixed.
+
+The first example we will go through is a 15 years old vulnerability that
+affected the random number generator (RNG) in Mac OS X [@Wang2015]. At some
+point in the past, this vulnerability affected all *BSD operating systems, as
+they have a common ancestor with Mac OS.
+
+In the random number generator of the system, more specifically in
+srandomdev(3), we can spot the following piece of code used in the seeding
+logic:
+
+      ``` {.c}
+      struct timeval tv;
+      unsigned long junk;
+      
+      gettimeofday(&tv, NULL);
+      srandom((getpid() << 16) ^ tv.tv_sec ^ tv.tv_usec ^ junk);
+      ```
+
+For generating a seed for the RNG, the code uses the current time and an
+uninitialized value from the stack, i.e. `junk`. This triggers undefined
+behavior as the C standard has no clear semantics for uninitialized loads.
+Because of that, there was a huge difference in the generated assembly code for
+two different Mac OS X releases.
+
+In Mac OS X 10.6 the generated code looked like this:
+
+      ``` {.asm}
+      leaq    0xe0(%rbp),%rdi
+      xorl    %esi,%esi
+      callq   0x001422ca      ; symbol stub for: _gettimeofday
+      callq   0x00142270      ; symbol stub for: _getpid
+      movq    0xe0(%rbp),%rdx
+      movl    0xe8(%rbp),%edi
+      xorl    %edx,%edi
+      shll    $0x10,%eax
+      xorl    %eax,%edi
+      xorl    %ebx,%edi
+      callq   0x00142d68      ; symbol stub for: _srandom
+      ```
+
+While for Mac OS X 10.7 the code looked like this:
+
+      ``` {.asm}
+      leaq    0xd8(%rbp),%rdi
+      xorl    %esi,%esi
+      callq   0x000a427e      ; symbol stub for: _gettimeofday
+      callq   0x000a3882      ; symbol stub for: _getpid
+      callq   0x000a4752      ; symbol stub for: _srandom
+      ```
+
+In the shorter version of the generated assembly code, the compiler dropped the
+whole argument of `srandom` as an optimization. While this code respects the
+standard, it leaves room for an attacker to exploit the system because the seed
+of the RNG can now be predicted. 
+
+In the meantime, this problem has be resovled in FreeBSD [@FbsdJunk], OpenBSD
+[@ObsdJunk].
+
+Current solutions for detecting this class of vulnerabilities include LLVM's
+MemorySanitizer and Valgrind.
+
+The next example covers a new type of undefined behavior that can easily
+introduce security vulnerabilities. This time we talk about dereferencing NULL
+pointers and what might go wrong with this operation. The following piece of
+code is taken from Linux and introduces a vulnerability by dereferencing the
+`tun` pointer before it checks that the pointer is valid:
+
+      ``` {.c}
+      unsigned int
+      tun_chr_poll(struct file *file, poll_table * wait)
+      {
+        struct tun_file *tfile = file->private_data;
+        struct tun_struct *tun = __tun_get(tfile);
+        struct sock *sk = tun->sk;
+        if (!tun)
+          return POLLERR;
+        ...
+      }
+      ```
+
+Normally, this would cause a crash in the kernel or the function would return
+POLLERR if address 0 was mapped in the address space. However the compiler
+assumes that `tun` is a valid pointer when the execution reaches the if
+statement.  This happens because it saw an earlier dereference just before the
+if statement.  In this situation, the check is considered redundant and deleted
+from the final binary. This allows an attacker to continue executing code from
+`tun_chr_poll` when address 0 is mapped.
+
+To mitigate against this situation, GCC developers added a flag called
+-fno-delete-null-pointer-checks that Linux integrated in its compiler
+configuration.
+
+Linux was not the only project that suffered from this problem. Chromium
+[@ChromiumIssue] and Mozilla [@MozillaIssue] had problems in the past with this
+
+There are also cases of security vulnerabilities that are not introduced by
+undefined behavior, the following piece of code is such an example. This was
+taken from the Linux kernel. Because the compiler sees that the pointer hash is
+never used after this point, it decides to delete the memset operation. We call
+this dead store optimization (DSO). This has serious security implications
+because the intention of the programmer was to delete the `hash` information
+from memory.
+
+      ``` {.c}
+      static void extract_buf(struct entropy_store *r, __u8 *out) {
+        ...
+        - memset(&hash, 0, sizeof(hash));
+        + memzero_explicit(&hash, sizeof(hash));
+      }
+      ```
+
+The solution Linux came with was to add a new function called `memzero_explicit`
+which under the hood looks like this:
+
+      ``` {.c}
+      void memzero_explicit(void *s, size_t count)
+      {
+        memset(s, 0, count);
+        OPTIMIZER_HIDE_VAR(s);
+      }
+      ```
+
+It still uses _memset_ to delete the associated security sensitive data, but it
+also tries to eliminate the risk of DSO by using the OPTIMIZER_HIDE_VAR macro.
+This, however, is not enough to fully eliminate dead stores [@MemZeroBarrier].
+In case of using LTO, the buffer `s` from is still vulnerable. For this reason,
+Linux maintainers added a further hardening mechanism by using a compiler
+barrier instead:
+
+      ``` {.c}
+      void memzero_explicit(void *s, size_t count)
+      {
+        memset(s, 0, count);
+        - OPTIMIZER_HIDE_VAR(s);
+        + barrier();
+      }
+      ```
+
+There is still room for improvement regarding the introduced barrier
+[@MemZeroDataBarrier]. If the content of the buffer is present in registers,
+then the compiler blindly proves again that the DSO can be triggered and the
+`memset` will be again deleted. To mitigate against this, the following patch
+was proposed:
+
+      ``` {.c}
+      + #define barrier_data(ptr) __asm__ __volatile__("": :"r"(ptr) :"memory")
+      
+      void memzero_explicit(void *s, size_t count)
+      {
+        memset(s, 0, count);
+        - barrier();
+        + barrier_data(s);
+      }
+      ```
+
+In this patch we create a new barrier that will be guaranted to put the content
+of the buffer in memory so that DSO can take no further effect. 
+
+Similar efforts were conducted in other projects such as OpenSSL
+[@OpenSSLMemClr]. The approach OpenSSL used is rather different but it achieves
+the same end goal, i.e. eliminating the effect of DSO. By making `memset_func` a
+volatile pointer to the actual implementation of `memset`, the compiler is
+forced to dereference the pointer to get to the actual `memset`, thus
+eliminating the risk of optimizing it out.
+
 # Physical attacks
 
 ::: TODO


### PR DESCRIPTION
This is the draft I was discussing with @kbeyls in #183.

One thing that I was thinking about is if this should be a separate chapter or it should be somehow integrated with the chapter about supply chain attacks. Any ideas?

This is far from perfect so any feedback is welcomed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/200)
<!-- Reviewable:end -->
