### PR TITLE
Introduce transient execution attacks

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -642,3 +642,34 @@ publisher = {Addison-Wesley Professional},
   url    = {https://people.kernel.org/kees/bounded-flexible-arrays-in-c},
   year   = {2023},
 }
+
+@InProceedings{Kocher2019,
+  author    = {Paul Kocher and Jann Horn and Anders Fogh and Daniel Genkin and Daniel Gruss and Werner Haas and Mike Hamburg and Moritz Lipp and Stefan Mangard and Thomas Prescher and Michael Schwarz and Yuval Yarom},
+  booktitle = {2019 {IEEE} Symposium on Security and Privacy ({SP})},
+  title     = {Spectre Attacks: Exploiting Speculative Execution},
+  year      = {2019},
+  publisher = {{IEEE}},
+  doi       = {10.1109/sp.2019.00002}
+}
+
+@inproceedings {Lipp2018,
+author = {Moritz Lipp and Michael Schwarz and Daniel Gruss and Thomas Prescher and Werner Haas and Anders Fogh and Jann Horn and Stefan Mangard and Paul Kocher and Daniel Genkin and Yuval Yarom and Mike Hamburg},
+title = {Meltdown: Reading Kernel Memory from User Space},
+booktitle = {27th USENIX Security Symposium (USENIX Security 18)},
+year = {2018},
+url = {https://www.usenix.org/conference/usenixsecurity18/presentation/lipp},
+}
+
+@InProceedings{Bulck2020,
+  author    = {Jo Van Bulck and Daniel Moghimi and Michael Schwarz and Moritz Lippi and Marina Minkin and Daniel Genkin and Yuval Yarom and Berk Sunar and Daniel Gruss and Frank Piessens},
+  booktitle = {2020 {IEEE} Symposium on Security and Privacy ({SP})},
+  title     = {{LVI}: Hijacking Transient Execution through Microarchitectural Load Value Injection},
+}
+
+@InProceedings{Canella2019,
+  author    = {Claudio Canella and Jo Van Bulck and Michael Schwarz and Moritz Lipp and Benjamin von Berg and Philipp Ortner and Frank Piessens and Dmitry Evtyushkin and Daniel Gruss},
+  booktitle = {28th {USENIX} Security Symposium ({USENIX} Security 19)},
+  title     = {A Systematic Evaluation of Transient Execution Attacks and Defenses},
+  year      = {2019},
+  url       = {https://www.usenix.org/conference/usenixsecurity19/presentation/canella},
+}

--- a/book.bib
+++ b/book.bib
@@ -673,3 +673,11 @@ url = {https://www.usenix.org/conference/usenixsecurity18/presentation/lipp},
   year      = {2019},
   url       = {https://www.usenix.org/conference/usenixsecurity19/presentation/canella},
 }
+
+@InProceedings{Mutlu2004,
+  author     = {Mutlu, Onur and Kim, Hyesoon and Armstrong, David N. and Patt, Yale N.},
+  booktitle  = {Proceedings of the 3rd workshop on Memory performance issues in conjunction with the 31st international symposium on computer architecture - WMPI ’04},
+  title      = {Understanding the effects of wrong-path memory references on processor performance},
+  year       = {2004},
+  doi        = {10.1145/1054943.1054951},
+}

--- a/book.md
+++ b/book.md
@@ -1882,7 +1882,7 @@ the spy runs. This is probably going to incur quite a bit of performance
 overhead, and may also not always possible e.g. when victim and spy are running
 at the same time on 2 CPUs sharing a cache level.
 
-## Branch-predictor based side channels
+## Branch-predictor based side-channels
 
 ### Branch predictors
 
@@ -1994,6 +1994,8 @@ Should we also discuss more "covert" channels here such as power analysis, etc?
 ## Transient execution attacks
 
 ### Transient execution
+
+#### Speculative execution
 
 CPUs execute sequences of instructions. There are often dependencies between
 instructions in the sequence. That means that the outcome of one instruction
@@ -2110,15 +2112,100 @@ architectural state. [Could we find a good reference that explains
 micro-architectural versus architectural state in more detail? Is "Computer
 Architecture: A Quantitative Approach" the best reference available?]{.todo}
 
+**Faulting instructions**\index{faulting instructions} are instructions that
+generate an exception at run-time. Many instructions can generate an exception,
+and are hence **potentially faulting**. For example most load and store
+instructions generate an exception when the accessed address is not mapped.
+Since so many instructions can generate an exception, processors typically
+speculate that they do not generate an exception to enable more parallel
+execution.
+
+When an instruction faults, the execution typically continues at another
+location. Any instructions later in the instruction stream which are being
+executed before the fault is detected are also called **transient
+instructions**\index{transient instructions}.
+
+There is a kind of control dependency between every potentially-faulting
+instruction and the next one, as the next instruction to be executed depends on
+whether the instruction generates an exception or not. We call out this
+dependency separately here as the transient execution attacks we'll describe
+next get classified based on whether they make use of transient instructions
+after a misprediction, or transient instructions after a faulting instructions.
+
+### Transient Execution Attacks
+
 **Transient execution attacks**\index{transient execution attacks} are a
 category of side-channel attacks that use the micro-architectural side-effects
 of transient execution as a side channel.
 
+The publication of the Spectre\index{Spectre} [@Kocher2019] and
+Meltdown\index{Meltdown} [@Lipp2018] attacks in 2018 started a period in which a
+large number of transient attacks were discovered and published. Most of them
+were given specific names, such as ZombieLoad, NetSpectre, LVI, Straight-line
+Speculation, etc. New variants continue to be published regularly.
+
+Covering each one of them in detail here would make the book overly lengthy, and
+may not necessarily help much with gaining a better insight in the common
+characteristics of transient attacks. Therefore, we'll try to put them into a
+few categories and describe the characteristics of each category.
+
 ::: TODO
-Write sections on specific transient execution attacks such as Spectre and
-Meltdown.
+Decide whether it's useful to talk about alternative categorizations of
+transient execution attacks, and if so, do add content.
+:::
+
+The categorization below is based on one proposed in [@Bulck2020]. There are
+alternative categorizations. [@Bulck2020] defines 4 big classes of transient
+side-channel attack categories, based on whether:
+
+1. The transient execution happens because of a misprediction, or a faulting
+   instruction.
+2. The attacker actively steers data or control flow of the transient execution
+   or not.
+
+This gives the following 4 categories:
+
++----------------+-------------------------+------------------------+
+|                | Steering of transient execution by attacker?     |
+|                +-------------------------+------------------------+
+|                | No (Leakage)            |  Yes (Injection)       |
++================+=========================+========================+
+| Misprediction  | Branch-predictor based  | Spectre-style attacks  |
+|                | side-channels           |                        |
++----------------+-------------------------+------------------------+
+| Faulting       | Meltdown-style attacks  | LVI-style attacks      |
++----------------+-------------------------+------------------------+
+
+#### Branch predictor-based side-channel attacks
+
+We discussed this category already in the section on
+[Side-channels through branch predictors](#side-channels-through-branch-predictors).
+
+#### Spectre-style attacks
+
+::: TODO
+Add a description of Spectre-style attacks such as Spectre-PHT, Spectre-BTB,
+Spectre-RSB, Spectre-STL, SpectreV1, SpectreV2, SpectreV3, SpectreV4,
+NetSpectre.
 [178]{.issue}
 :::
+
+#### Meltdown-style attacks
+
+::: TODO
+Add a description of Meltdown-style attacks such as Meltdown, Foreshadow,
+LazyFP, Fallout, ZombieLoad, RIDL.
+[178]{.issue}
+:::
+
+#### LVI-style attacks
+
+::: TODO
+Add a description of LVI-style attacks.
+[178]{.issue}
+:::
+
+### Mitigations against transient execution attacks
 
 #### Site isolation
 

--- a/book.md
+++ b/book.md
@@ -2121,8 +2121,8 @@ speculate that they do not generate an exception to enable more parallel
 execution.
 
 When an instruction faults, the execution typically continues at another
-location. Any instructions later in the instruction stream which are being
-executed before the fault is detected are also called **transient
+location. Any instructions later in the instruction stream which are
+speculatively executed before the fault is detected are also called **transient
 instructions**\index{transient instructions}.
 
 There is a kind of control dependency between every potentially-faulting
@@ -2130,7 +2130,7 @@ instruction and the next one, as the next instruction to be executed depends on
 whether the instruction generates an exception or not. We call out this
 dependency separately here as the transient execution attacks we'll describe
 next get classified based on whether they make use of transient instructions
-after a misprediction, or transient instructions after a faulting instructions.
+after a misprediction, or transient instructions after a faulting instruction.
 
 ### Transient Execution Attacks
 

--- a/book.md
+++ b/book.md
@@ -2083,7 +2083,9 @@ the correct, non-negated, value in register `x0`.
 
 Any instructions that are executed under so-called
 **mis-speculation**\index{mis-speculation}, are called **transient
-instructions**\index{transient instructions}.
+instructions**\index{transient instructions}.^[Transient instructions caused by
+incorrect branch-direction prediction have also been called **wrong-path
+instructions**\index{wrong-patch instructions} @Mutlu2004]
 
 The paragraph above says "*the system state that affects the correct execution
 of the program, needs to be undone*". There is a lot of system state that does
@@ -2149,9 +2151,9 @@ may not necessarily help much with gaining a better insight in the common
 characteristics of transient attacks. Therefore, we'll try to put them into a
 few categories and describe the characteristics of each category.
 
-::: TODO
-Decide whether it's useful to talk about alternative categorizations of
-transient execution attacks, and if so, do add content.
+::: TODO Decide whether it's useful to talk about alternative categorizations of
+transient execution attacks, and if so, do add content. Consider pointing to
+[https://github.com/MattPD/cpplinks/blob/master/comparch.micro.channels.md](https://github.com/MattPD/cpplinks/blob/master/comparch.micro.channels.md)
 :::
 
 The categorization below is based on one proposed in [@Bulck2020]. There are


### PR DESCRIPTION
This patch only introduces a high-level categorization of transient execution attacks. The detailed description of the various Spectre-, Meltdown-, LVI-style attacks will be for later patches.

Note that the table uses the pandoc grid table syntax, see https://pandoc.org/chunkedhtml-demo/8.9-tables.html, section 8.9.4. The version of pandoc we use in our docker image does not support that yet. But it's the only variant of table that supports multi-row and multi-column cells which I'd like to use for this table. I'll need to figure out how to update the version of pandoc in the docker container we use. That in itself shouldn't be too hard. The annoying thing is that the pandoc filter pandoc-fignos that we use is no longer maintained and does not work anymore with recent versions of pandoc....
I'll look into update the version of pandoc we use in a later commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/224)
<!-- Reviewable:end -->
