### PR TITLE
Update pandoc to recent version (3.0.1) so that we can use grid tables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build/index.html: build/book.html build
 build/book.tex: book.md book.bib Makefile build theme/tex/pandoc_template.tex \
 				theme/html/markup_issue.lua \
 				theme/html/markup_todo.lua \
-			    theme/fignos.lua \
+				theme/fignos.lua \
 				$(pdfimages)
 	pandoc $< -t latex \
 		--template theme/tex/pandoc_template.tex \

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,18 @@ PANDOCFLAGS = \
 	      --number-sections \
 	      --resource-path=. \
 	      --standalone \
-	      --self-contained \
-	      --filter pandoc-fignos \
-	      --filter pandoc-citeproc \
+	      --embed-resources \
 	      --metadata=VERSION:$(version)
 
+COMMONFILTERS = \
+          --lua-filter theme/fignos.lua \
+          --citeproc
+
 .PHONY: all clean pdf html
-all: pdf html default_pandoc_html_template default_pandoc_latex_template
+all: pdf html default_pandoc_html_template default_pandoc_latex_template native
 pdf: build/book.pdf
 html: build/book.html build/default.css build/index.html
+native: build/book.native
 
 # The source of images are in SVG format.
 # The below lines define to convert the SVG source images to PDF images such
@@ -42,6 +45,7 @@ build/book.html: book.md book.bib Makefile build theme/html/pandoc_template.html
 				 theme/html/convert_to_sidenote.lua \
 				 theme/html/markup_issue.lua \
 				 theme/html/markup_todo.lua \
+				 theme/fignos.lua \
 				 build/default.css $(svgimages)
 	pandoc $< -t html \
 		--template theme/html/pandoc_template.html \
@@ -51,7 +55,10 @@ build/book.html: book.md book.bib Makefile build theme/html/pandoc_template.html
 		--lua-filter theme/html/convert_to_sidenote.lua \
 		-M css=build/default.css \
 		--default-image-extension=svg \
-		-o $@ $(PANDOCFLAGS)
+		-o $@ $(PANDOCFLAGS) $(COMMONFILTERS)
+
+build/book.native: book.md book.bib Makefile build
+	pandoc $< -t native -o $@ $(PANDOCFLAGS)
 
 build/index.html: build/book.html build
 	cp build/book.html build/index.html
@@ -59,13 +66,14 @@ build/index.html: build/book.html build
 build/book.tex: book.md book.bib Makefile build theme/tex/pandoc_template.tex \
 				theme/html/markup_issue.lua \
 				theme/html/markup_todo.lua \
+			    theme/fignos.lua \
 				$(pdfimages)
 	pandoc $< -t latex \
 		--template theme/tex/pandoc_template.tex \
 		--default-image-extension=pdf \
 		--lua-filter theme/html/markup_issue.lua \
 		--lua-filter theme/html/markup_todo.lua \
-		-o $@ $(PANDOCFLAGS)
+		-o $@ $(PANDOCFLAGS) $(COMMONFILTERS)
 
 build/book.pdf: build/book.tex Makefile build
 	latexmk -pdf build/book.tex -output-directory=build

--- a/book.md
+++ b/book.md
@@ -31,6 +31,8 @@ header-includes:
     \stepcounter{TodoCounter}
     \oldtodo[inline,caption={\arabic{TodoCounter}. #1}]{\bcpanchant \textit{#1}}
   }
+  \usepackage{caption}
+  \captionsetup[figure]{labelformat=empty}
   ```
 ...
 
@@ -1695,8 +1697,8 @@ assume $N=12$ for a 12-way set-associative cache, the total cache size is
 $N*2^L*2^S=12*64*32=24$KB.](img/CacheIndexing){ width=100% #fig:cache-indexing}
 
 Specific bits in the memory address are used for different cache indexing
-purposes, as illustrated in +@fig:cache-indexing. The least-significant $L$
-bits, where $2^L$ is the cache line size, are used to compute an address's
+purposes, as illustrated in figure @fig:cache-indexing. The least-significant
+$L$ bits, where $2^L$ is the cache line size, are used to compute an address's
 offset within a cache line. The next $S$ bits, where $2^S$ is the number of
 cache sets, are used to determine which cache set an address maps to. The
 remaining top bits are "tag bits". They are stored alongside a line in the cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: CC-BY-4.0
 # SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
 # syntax=docker/dockerfile:1
-#FROM ubuntu:23.10
 FROM debian:trixie
 # 1. install pandoc and texlive dependencies
 #    Also install git as we need that for computing version numbers.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: CC-BY-4.0
 # SPDX-FileCopyrightText: © 2021 Arm Limited <kristof.beyls@arm.com>
 # syntax=docker/dockerfile:1
-FROM ubuntu:20.04
+#FROM ubuntu:23.10
+FROM debian:trixie
 # 1. install pandoc and texlive dependencies
 #    Also install git as we need that for computing version numbers.
 #    Also install librsvg2-bin to enable pandoc to convert SVG images to PDF.
 #    Also install python as the pandoc-fignos filter depends on it.
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y \
-            wget perl pandoc make pandoc-citeproc git librsvg2-bin python3-pip && \
+            wget perl pandoc make git librsvg2-bin python3-pip && \
     rm -rf /var/lib/apt/lists/*
-# 2. Install pandoc-fignos filter
-RUN pip3 install pandoc-fignos
-# 3. Install LaTeX directly from stable Texlive 2020 final repo
+# 2. Install LaTeX directly from stable Texlive 2020 final repo
 # (We could alternatively install a base Texlive using "apt-get install
 #  texlive-latex-extra", and then add extra packages using tlmgr.
 #  The drawbacks of that approach are:
@@ -44,14 +43,18 @@ RUN cd /root && \
         -profile texlive.profile \
         -repository https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2020/tlnet-final && \
     ln -s /texlive/2020/bin/* /texlive/bin
-# 4. Add texlive and pip3 binaries to PATH so they can be used easily.
+# 3. Add texlive binaries to PATH so they can be used easily.
 ENV PATH=/texlive/bin:$PATH
-# 5. install latex too (the minimal scheme selected above does not install latex)
+# 4. install latex too (the minimal scheme selected above does not install latex)
 RUN tlmgr install latex latex-bin latexmk
-# 6. install extra latex packages needed for pandoc:
-RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb booktabs graphics hyperref xcolor ulem geometry setspace babel upquote microtype parskip xurl bookmark footnotehyper mdwtools kvoptions etoolbox pdftexcmds infwarerr grffile cleveref caption
+# 5. install extra latex packages needed for pandoc:
+RUN tlmgr install amsfonts amsmath lm unicode-math iftex listings fancyvrb \
+      booktabs graphics hyperref xcolor ulem geometry setspace babel upquote \
+      microtype parskip xurl bookmark footnotehyper mdwtools kvoptions \
+      etoolbox pdftexcmds infwarerr grffile cleveref caption multirow
 # 6. install extra packages needed for the book specifically:
-RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil pst-node mdframed zref needspace mptopdf
+RUN tlmgr install todonotes epstopdf-pkg bclogo pstricks pst-grad pst-coil \
+      pst-node mdframed zref needspace mptopdf
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 cd /src
-echo $PWD
 ls -al
+echo pandoc version:
+pandoc --version
 sh -c "make $*"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cd /src
 ls -al

--- a/theme/fignos.lua
+++ b/theme/fignos.lua
@@ -1,0 +1,70 @@
+-- This lua pandoc filter converts @fig: references.
+-- similarly to how https://github.com/tomduck/pandoc-fignos works.
+-- pandoc-fignos is no longer maintained, therefore, we re-implement
+-- the functionality of it that we depend on in our own filter here.
+-- local logging = require 'theme/html/logging'
+
+figure_counter = 0;
+label2id = {};
+
+function get_next_figure_counter_and_id(label)
+  figure_counter = figure_counter + 1;
+  -- figure_id = "figure_" .. figure_counter;
+  label2id[label] = {count = figure_counter, pandocid = label};
+  return figure_counter, figure_id;
+end
+
+function get_figure_count(label)
+  return label2id[label].count
+end
+
+function is_fig_label(label)
+  return label:find("^fig:")
+end
+
+-- First find all Figures and give them ids and labels.
+-- Also prepend the caption with "Figure x:"
+function process_figures (figure)
+  local label = figure.identifier;
+  -- Only process Figure's who's label starts with "fig:"
+  if not is_fig_label(label) then
+    return;
+  end
+  figure_count, figure_id = get_next_figure_counter_and_id(label);
+  -- add "Figure x: " to start of caption
+  prefix = "Figure "..get_figure_count(label)..": ";
+  if #figure.caption.long > 0 and figure.caption.long[1].tag == "Plain" then
+    -- Avoid creating more blocks, as that will result in the prefix
+    -- being on a line by it's own in the LaTeX/PDF output.
+    pandoc.List.insert(figure.caption.long[1].content, 1, prefix);
+  else
+    pandoc.List.insert(figure.caption.long, 1, prefix);
+  end
+  return figure;
+end
+
+-- convert Cite if the tag starts with @fig: to a link to the
+-- corresponding figure.
+function process_cites (cite)
+  local tag = cite.tag;
+  if #cite.citations ~= 1 then
+    -- if the number of citations is more than 1, than this is not a reference
+    -- to a figure
+    return
+  end
+  local label = cite.citations[1].id;
+  if not is_fig_label(label) then
+    return;
+  end
+  if label2id[label] == nil then
+    -- label for figure is not found
+    io.stderr:write('Reference @'..label..' found, but no figure found with that label\n');
+    return
+  end
+  local figure_pandocid = label2id[label].pandocid;
+  return pandoc.Link(pandoc.Str(get_figure_count(label)), '#'..figure_pandocid);
+end
+
+-- The below ensures that first all figures are processed, and then all cites
+-- are processed.
+return {{Figure = process_figures}, {Cite = process_cites}}

--- a/theme/html/clickable_headers.lua
+++ b/theme/html/clickable_headers.lua
@@ -2,10 +2,10 @@ function Header (h)
   -- if AST object is header type, it is passed through this function
 
   -- create link AST node and assign to 'selflink' class for CSS handle
-  local self = pandoc.Link({pandoc.Str '§'}, '#' .. h.identifier)
+  local self = pandoc.Link({pandoc.Str ''}, '#' .. h.identifier)
   self.classes = {'selflink'}
 
   -- update the content
-  h.content = h.content .. {pandoc.Space(), self}
+  h.content = h.content .. {self}
   return h
 end

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -43,20 +43,22 @@ body {
   font-size: 0.875em;
 }
 
-/* Hide header link by default
-   except on mouse hover, or
-   click/tap (for mobile users) */
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-  visibility: hidden;
-  font-size: 85%;
+.selflink {
+  text-decoration: none;
 }
-h1:hover a, h1:active a,
-h2:hover a, h2:active a,
-h3:hover a, h3:active a,
-h4:hover a, h4:active a,
-h5:hover a, h5:active a,
-h6:hover a, h6:active a {
-  visibility: visible;
+.selflink::after {
+  content: ' 🔗';
+  font-size: 14pt;
+  vertical-align: middle;
+  opacity: 0.5;
+}
+h1:hover > .selflink::after,
+h2:hover > .selflink::after,
+h3:hover > .selflink::after,
+h4:hover > .selflink::after,
+h5:hover > .selflink::after,
+h6:hover > .selflink::after {
+  opacity: 1;
 }
 
 /* Set layout and size for top-level divs:

--- a/theme/tex/pandoc_template.tex
+++ b/theme/tex/pandoc_template.tex
@@ -1,15 +1,37 @@
-\PassOptionsToPackage{unicode=true$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref} % options for packages loaded elsewhere
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
 \PassOptionsToPackage{hyphens}{url}
 $if(colorlinks)$
-\PassOptionsToPackage{dvipsnames,svgnames*,x11names*}{xcolor}
-$endif$$if(dir)$$if(latex-dir-rtl)$
-\PassOptionsToPackage{RTLdocument}{bidi}
-$endif$$endif$%
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$if(beamer)$ignorenonframetext,$if(handout)$handout,$endif$$if(aspectratio)$aspectratio=$aspectratio$,$endif$$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+\PassOptionsToPackage{dvipsnames,svgnames,x11names}{xcolor}
+$endif$
+$if(CJKmainfont)$
+\PassOptionsToPackage{space}{xeCJK}
+$endif$
+%
+\documentclass[
+$if(fontsize)$
+  $fontsize$,
+$endif$
+$if(papersize)$
+  $papersize$paper,
+$endif$
+$if(beamer)$
+  ignorenonframetext,
+$if(handout)$
+  handout,
+$endif$
+$if(aspectratio)$
+  aspectratio=$aspectratio$,
+$endif$
+$endif$
+$for(classoption)$
+  $classoption$$sep$,
+$endfor$
+]{$documentclass$}
 $if(beamer)$
 $if(background-image)$
 \usebackgroundtemplate{%
-\includegraphics[width=\paperwidth]{$background-image$}%
+  \includegraphics[width=\paperwidth]{$background-image$}%
 }
 $endif$
 \usepackage{pgfpages}
@@ -20,27 +42,27 @@ $endif$
 $for(beameroption)$
 \setbeameroption{$beameroption$}
 $endfor$
-% Prevent slide breaks in the middle of a paragraph:
+% Prevent slide breaks in the middle of a paragraph
 \widowpenalties 1 10000
 \raggedbottom
 $if(section-titles)$
 \setbeamertemplate{part page}{
-\centering
-\begin{beamercolorbox}[sep=16pt,center]{part title}
-  \usebeamerfont{part title}\insertpart\par
-\end{beamercolorbox}
+  \centering
+  \begin{beamercolorbox}[sep=16pt,center]{part title}
+    \usebeamerfont{part title}\insertpart\par
+  \end{beamercolorbox}
 }
 \setbeamertemplate{section page}{
-\centering
-\begin{beamercolorbox}[sep=12pt,center]{part title}
-  \usebeamerfont{section title}\insertsection\par
-\end{beamercolorbox}
+  \centering
+  \begin{beamercolorbox}[sep=12pt,center]{part title}
+    \usebeamerfont{section title}\insertsection\par
+  \end{beamercolorbox}
 }
 \setbeamertemplate{subsection page}{
-\centering
-\begin{beamercolorbox}[sep=8pt,center]{part title}
-  \usebeamerfont{subsection title}\insertsubsection\par
-\end{beamercolorbox}
+  \centering
+  \begin{beamercolorbox}[sep=8pt,center]{part title}
+    \usebeamerfont{subsection title}\insertsubsection\par
+  \end{beamercolorbox}
 }
 \AtBeginPart{
   \frame{\partpage}
@@ -59,6 +81,7 @@ $endif$
 $if(beamerarticle)$
 \usepackage{beamerarticle} % needs to be loaded first
 $endif$
+\usepackage{amsmath,amssymb}
 $if(fontfamily)$
 \usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$
@@ -66,18 +89,15 @@ $else$
 $endif$
 $if(linestretch)$
 \usepackage{setspace}
-\setstretch{$linestretch$}
 $endif$
-\usepackage{amssymb,amsmath}
-\usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
-\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+\usepackage{iftex}
+\ifPDFTeX
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
-\else % if luatex or xelatex
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
 $if(mathspec)$
-  \ifxetex
+  \ifXeTeX
     \usepackage{mathspec}
   \else
     \usepackage{unicode-math}
@@ -85,25 +105,23 @@ $if(mathspec)$
 $else$
   \usepackage{unicode-math}
 $endif$
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-$for(fontfamilies)$
-  \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
-$endfor$
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 $if(mainfont)$
-    \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
-$endif$
-$if(romanfont)$
-	\setromanfont[$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$]{$romanfont$}
+  \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
 $if(sansfont)$
-    \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
 $endif$
 $if(monofont)$
-    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
+  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$]{$monofont$}
 $endif$
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}
+$endfor$
 $if(mathfont)$
 $if(mathspec)$
-  \ifxetex
+  \ifXeTeX
     \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
   \else
     \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
@@ -113,23 +131,42 @@ $else$
 $endif$
 $endif$
 $if(CJKmainfont)$
-  \ifxetex
+  \ifXeTeX
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
   \fi
 $endif$
 $if(luatexjapresetoptions)$
-  \ifluatex
+  \ifLuaTeX
     \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
   \fi
 $endif$
 $if(CJKmainfont)$
-  \ifluatex
+  \ifLuaTeX
     \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
     \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
   \fi
 $endif$
 \fi
+$if(zero-width-non-joiner)$
+%% Support for zero-width non-joiner characters.
+\makeatletter
+\def\zerowidthnonjoiner{%
+  % Prevent ligatures and adjust kerning, but still support hyphenating.
+  \texorpdfstring{%
+    \textormath{\nobreak\discretionary{-}{}{\kern.03em}%
+      \ifvmode\else\nobreak\hskip\z@skip\fi}{}%
+  }{}%
+}
+\makeatother
+\ifPDFTeX
+  \DeclareUnicodeCharacter{200C}{\zerowidthnonjoiner}
+\else
+  \catcode`^^^^200c=\active
+  \protected\def ^^^^200c{\zerowidthnonjoiner}
+\fi
+%% End of ZWNJ support
+$endif$
 $if(beamer)$
 $if(theme)$
 \usetheme[$for(themeoptions)$$themeoptions$$sep$,$endfor$]{$theme$}
@@ -150,55 +187,67 @@ $if(outertheme)$
 \useoutertheme{$outertheme$}
 $endif$
 $endif$
-% use upquote if available, for straight quotes in verbatim environments
+% Use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
-% use microtype if available
-\IfFileExists{microtype.sty}{%
-\usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
-\UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 $if(indent)$
 $else$
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
 $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 $endif$
-$if(colorlinks)$
 \usepackage{xcolor}
-$endif$
-\usepackage{hyperref}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \hypersetup{
 $if(title-meta)$
-            pdftitle={$title-meta$},
+  pdftitle={$title-meta$},
 $endif$
 $if(author-meta)$
-            pdfauthor={$author-meta$},
+  pdfauthor={$author-meta$},
+$endif$
+$if(lang)$
+  pdflang={$lang$},
+$endif$
+$if(subject)$
+  pdfsubject={$subject$},
 $endif$
 $if(keywords)$
-            pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
+  pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
 $endif$
 $if(colorlinks)$
-            colorlinks=true,
-            linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
-            filecolor=$if(filecolor)$$filecolor$$else$Maroon$endif$,
-            citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
-            urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+  colorlinks=true,
+  linkcolor={$if(linkcolor)$$linkcolor$$else$Maroon$endif$},
+  filecolor={$if(filecolor)$$filecolor$$else$Maroon$endif$},
+  citecolor={$if(citecolor)$$citecolor$$else$Blue$endif$},
+  urlcolor={$if(urlcolor)$$urlcolor$$else$Blue$endif$},
 $else$
-            pdfborder={0 0 0},
+  hidelinks,
 $endif$
-            breaklinks=true}
-\urlstyle{same}  % don't use monospace font for urls
+  pdfcreator={LaTeX via pandoc}}
+\urlstyle{same} % disable monospaced font for URLs
 $if(verbatim-in-note)$
-\VerbatimFootnotes % allows verbatim text in footnotes
+\VerbatimFootnotes % allow verbatim text in footnotes
 $endif$
 $if(geometry)$
+$if(beamer)$
+\geometry{$for(geometry)$$geometry$$sep$,$endfor$}
+$else$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
 $endif$
 $if(beamer)$
 \newif\ifbibliography
@@ -206,6 +255,8 @@ $endif$
 $if(listings)$
 \usepackage{listings}
 \newcommand{\passthrough}[1]{#1}
+\lstset{defaultdialect=[5.3]Lua}
+\lstset{defaultdialect=[x86masm]Assembler}
 $endif$
 $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
@@ -214,20 +265,30 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 $if(tables)$
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs,array}
+$if(multirow)$
+\usepackage{multirow}
+$endif$
+\usepackage{calc} % for calculating minipage widths
 $if(beamer)$
 \usepackage{caption}
-% These lines are needed to make table captions work with longtable:
+% Make caption package work with longtable
 \makeatletter
 \def\fnum@table{\tablename~\thetable}
 \makeatother
 $else$
-% Fix footnotes in tables (requires footnote package)
-\IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{longtable}}{}
+% Correct order of tables after \paragraph or \subparagraph
+\usepackage{etoolbox}
+\makeatletter
+\patchcmd\longtable{\par}{\if@noskipsec\mbox{}\fi\par}{}{}
+\makeatother
+% Allow footnotes in longtable head/foot
+\IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
+\makesavenoteenv{longtable}
 $endif$
 $endif$
 $if(graphics)$
-\usepackage{graphicx,grffile}
+\usepackage{graphicx}
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
@@ -236,72 +297,93 @@ $if(graphics)$
 % margins by default, and it is still possible to overwrite the defaults
 % using explicit options in \includegraphics[width, height, ...]{}
 \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
 $endif$
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:
 \DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}
 $endif$
 $if(strikeout)$
+$-- also used for underline
 \usepackage[normalem]{ulem}
-% avoid problems with \sout in headers with hyperref:
+% Avoid problems with \sout in headers with hyperref
 \pdfstringdefDisableCommands{\renewcommand{\sout}{}}
 $endif$
-\setlength{\emergencystretch}{3em}  % prevent overfull lines
+\setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 $if(numbersections)$
 \setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
 $else$
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 $endif$
 $if(beamer)$
 $else$
-$if(subparagraph)$
-$else$
-% Redefines (sub)paragraphs to behave more like sections
+$if(block-headings)$
+% Make \paragraph and \subparagraph free-standing
 \ifx\paragraph\undefined\else
-\let\oldparagraph\paragraph
-\renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+  \let\oldparagraph\paragraph
+  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
 \fi
 \ifx\subparagraph\undefined\else
-\let\oldsubparagraph\subparagraph
-\renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+  \let\oldsubparagraph\subparagraph
+  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
 \fi
 $endif$
 $endif$
 $if(pagestyle)$
 \pagestyle{$pagestyle$}
 $endif$
-
-% set default figure placement to htbp
-\makeatletter
-\def\fps@figure{htbp}
-\makeatother
-
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newlength{\cslentryspacingunit} % times entry-spacing
+\setlength{\cslentryspacingunit}{\parskip}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1
+  \let\oldpar\par
+  \def\par{\hangindent=\cslhangindent\oldpar}
+  \fi
+  % set entry spacing
+  \setlength{\parskip}{#2\cslentryspacingunit}
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+$if(lang)$
+\ifLuaTeX
+\usepackage[bidi=basic]{babel}
+\else
+\usepackage[bidi=default]{babel}
+\fi
+\babelprovide[main,import]{$babel-lang$}
+$for(babel-otherlangs)$
+\babelprovide[import]{$babel-otherlangs$}
+$endfor$
+% get rid of language-specific shorthands (see #6817):
+\let\LanguageShortHands\languageshorthands
+\def\languageshorthands#1{}
+$endif$
 $for(header-includes)$
 $header-includes$
 $endfor$
-$if(lang)$
-\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
-$if(babel-newcommands)$
-  $babel-newcommands$
-$endif$
-\else
-  % load polyglossia as late as possible as it *could* call bidi if RTL lang (e.g. Hebrew or Arabic)
-  \usepackage{polyglossia}
-  \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
-$for(polyglossia-otherlangs)$
-  \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
-$endfor$
+\ifLuaTeX
+  \usepackage{selnolig}  % disable illegal ligatures
 \fi
-$endif$
 $if(dir)$
-\ifxetex
-  % load bidi as late as possible as it modifies e.g. graphicx
-  \usepackage{bidi}
-\fi
-\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+\ifPDFTeX
   \TeXXeTstate=1
   \newcommand{\RL}[1]{\beginR #1\endR}
   \newcommand{\LR}[1]{\beginL #1\endL}
@@ -319,23 +401,34 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
+$if(nocite-ids)$
+\nocite{$for(nocite-ids)$$it$$sep$, $endfor$}
+$endif$
+$if(csquotes)$
+\usepackage{csquotes}
+$endif$
 
 $if(title)$
 \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
 $endif$
 $if(subtitle)$
-\providecommand{\subtitle}[1]{}
+$if(beamer)$
+$else$
+\usepackage{etoolbox}
+\makeatletter
+\providecommand{\subtitle}[1]{% add subtitle to \maketitle
+  \apptocmd{\@title}{\par {\large #1 \par}}{}{}
+}
+\makeatother
+$endif$
 \subtitle{$subtitle$}
 $endif$
-$if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
-$endif$
-$if(institute)$
-\providecommand{\institute}[1]{}
-\institute{$for(institute)$$institute$$sep$ \and $endfor$}
-$endif$
 \date{$date$}
 $if(beamer)$
+$if(institute)$
+\institute{$for(institute)$$institute$$sep$ \and $endfor$}
+$endif$
 $if(titlegraphic)$
 \titlegraphic{\includegraphics{$titlegraphic$}}
 $endif$
@@ -345,6 +438,9 @@ $endif$
 $endif$
 
 \begin{document}
+$if(has-frontmatter)$
+\frontmatter
+$endif$
 $if(title)$
 $if(beamer)$
 \frame{\titlepage}
@@ -383,11 +479,11 @@ $if(toc-title)$
 \renewcommand*\contentsname{$toc-title$}
 $endif$
 $if(beamer)$
-\begin{frame}
+\begin{frame}[allowframebreaks]
 $if(toc-title)$
-\frametitle{$toc-title$}
+  \frametitle{$toc-title$}
 $endif$
-\tableofcontents[hideallsubsections]
+  \tableofcontents[hideallsubsections]
 \end{frame}
 $else$
 {
@@ -399,18 +495,27 @@ $endif$
 }
 $endif$
 $endif$
-$if(lot)$
-\listoftables
-$endif$
 $if(lof)$
 \listoffigures
 $endif$
+$if(lot)$
+\listoftables
+$endif$
+$if(linestretch)$
+\setstretch{$linestretch$}
+$endif$
+$if(has-frontmatter)$
+\mainmatter
+$endif$
 $body$
 
+$if(has-frontmatter)$
+\backmatter
+$endif$
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$
-$if(book-class)$
+$if(has-chapters)$
 \renewcommand\bibname{$biblio-title$}
 $else$
 \renewcommand\refname{$biblio-title$}
@@ -418,9 +523,9 @@ $endif$
 $endif$
 $if(beamer)$
 \begin{frame}[allowframebreaks]{$biblio-title$}
-\bibliographytrue
+  \bibliographytrue
 $endif$
-\bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+  \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 $if(beamer)$
 \end{frame}
 $endif$
@@ -430,8 +535,8 @@ $endif$
 $if(biblatex)$
 $if(beamer)$
 \begin{frame}[allowframebreaks]{$biblio-title$}
-\bibliographytrue
-\printbibliography[heading=none]
+  \bibliographytrue
+  \printbibliography[heading=none]
 \end{frame}
 $else$
 \printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$


### PR DESCRIPTION
pandoc-fignos is no longer supported on recent pandoc versions, so instead, this commit adds the simple lua script theme/fignos.lua that implements just the functionality that we are using. This results in the figure numbering in the PDF to no use chapter-based numbering (e.g. figure 2.3 for the 3rd figure in chapter 2), but rather uses linear numbering (figures are numbered from 1 to N throughout the whole document). This makes it consistent with how they are numbered in the HTML output, so could be argued to actually be an improvement.

Diffing the tex output before and after this patch shows that the only other difference is a minute difference in the links used for citations, which is presumably caused by using the pandoc built-in 'citeproc' rather than the deprecated pandoc-citeproc filter.

The HTML output is harder to diff. The older version of pandoc creates very long HTML lines, whereas the newer version of pandoc seemingly tries hard to make the HTML output fit within an 80-column width.

As far as I can see, there are no regressions.
The only differences I've spotted are the ones described above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/225)
<!-- Reviewable:end -->
