### PR TITLE
book.md: fix bib reference typo for array bounds post

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -638,7 +638,7 @@ publisher = {Addison-Wesley Professional},
 
 @Electronic{Cook2023,
   author = {Kees Cook},
-  title  = {Bounded Flexible Arrays in C},
+  title  = {Bounded Flexible Arrays in {C}},
   url    = {https://people.kernel.org/kees/bounded-flexible-arrays-in-c},
   year   = {2023},
 }

--- a/book.md
+++ b/book.md
@@ -1331,8 +1331,7 @@ will include bounds checks.
 
 Successfully using bounds checking compiler features for a large codebase
 requires substantial effort. An example of this is refactoring the Linux kernel
-to use bounds checks for flexible arrays, as described in [Kees Cook's
-blog]([@Cook2023]).
+to use bounds checks for flexible arrays, as described in [@Cook2023].
 
 There are also hardware-based mitigations for violations of spatial memory
 safety. For example,


### PR DESCRIPTION
Removes extra []s around the @Cook2023 bib reference so the URL will render correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/228)
<!-- Reviewable:end -->
