### PR TITLE
[precommit testing] update checkout and upload-artifact actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -20,7 +20,7 @@ jobs:
       run: ./build_with_docker.sh
 
     - name: Archive PDF, HTML and EPUB output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: HTML, PDF and EPUB books
         path: |


### PR DESCRIPTION
The versions v2 that we used until now have been deprecated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/237)
<!-- Reviewable:end -->
