### PR TITLE
Update bibliography for Dullien2020

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -152,7 +152,8 @@ Please keep the comma after the author's name
   volume    = {8},
   number    = {2},
   pages     = {391-403},
-  doi       = {10.1109/TETC.2017.2785300}
+  keywords  = {Software;Programming;Complexity theory;Transducers;Concrete;Cryptography;Computer security;computer hacking;computation theory;information security;language-theoretic security},
+  doi       = {10.1109/TETC.2017.2785299}
 }
 
 @Electronic{Beer2020,


### PR DESCRIPTION
The previous DOI was broken, so I updated the citation data. (This also adds keywords.)

I checked with a quick shell script that other DOIs don’t return 404s, so this should be the only error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/254)
<!-- Reviewable:end -->
