### PR TITLE
Capitalize LLSoftSecBook in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# llsoftsecbook: a book on Low-Level Software Security for Compiler Developers
+# LLSoftSecBook: a book on Low-Level Software Security for Compiler Developers
 
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Build book with docker container CI](https://github.com/llsoftsec/llsoftsecbook/actions/workflows/main.yml/badge.svg)](https://github.com/llsoftsec/llsoftsecbook/actions/workflows/main.yml)


### PR DESCRIPTION
We use the capitalized spelling LLSoftSecBook in hash tags on social media.
We may as well use the same capitalization in the README