### PR TITLE
Retain scroll position on page reload

### DIFF
--- a/theme/html/pandoc_template.html
+++ b/theme/html/pandoc_template.html
@@ -195,9 +195,24 @@ $body$
     return width>=1200;
   }
 
+  // Make sure that on reload, the scroll position of the main content
+  // is restored to the current position. The next few lines store the
+  // current scroll position before the page is unloaded.
+  // The actual restoring happens in the document.ready function.
+  jQuery(window).on('beforeunload', function () {
+    sessionStorage.setItem('mainScrollTop',
+                           jQuery('#main-content-col').scrollTop());
+  });
+
   jQuery(document).ready(function() {
     let toc_sidebar = jQuery('#toc-sidebar');
     let main_content_col = jQuery('#main-content-col');
+
+    // Restore scroll position of the main content column.
+    var savedScroll = sessionStorage.getItem('mainScrollTop');
+    if (savedScroll !== null) {
+      main_content_col.scrollTop(parseInt(savedScroll, 10));
+    }
 
     function setTocVisibility(visible) {
       if (visible) {


### PR DESCRIPTION
When writing new content, I often reload the HTML version of the book, to see what the result of new writing looks like once rendered.
It is very annoying that on reload, the page jumps back to the very top of the content.
This patch addresses that: on reload, the current scroll position is retained.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/266)
<!-- Reviewable:end -->
