### PR TITLE
Copy-edit: pedantry about NULL versus NUL.

### DIFF
--- a/book.md
+++ b/book.md
@@ -620,15 +620,16 @@ fake call stack somewhere else, for example on the heap, and use a primitive
 that changes the stack pointer's value instead. This is known as stack
 pivoting\index{stack pivoting}.
 
-Note that this fake call stack contains NULL bytes, even without considering
+Note that this fake call stack contains zero bytes, even without considering
 the exact values of the various return addresses included. An overflow bug that
 is based on a C-style string operation would not allow an attacker to replace
 the stack contents with this fake call stack in one go, since C-style strings
-are null-terminated and copying the fake stack contents would stop once the
-first NULL byte is encountered. The ROP chain would therefore need to be
-adjusted so that it doesn't contain NULL bytes, for example by initially
-replacing the NULL bytes with a different byte and adding some more gadgets to
-the ROP chain that write zero to those stack locations.
+are [null-terminated](https://en.wikipedia.org/wiki/Null-terminated_string) and
+copying the fake stack contents would stop once the first zero byte is
+encountered. The ROP chain would therefore need to be adjusted so that it
+doesn't contain zero bytes, for example by initially replacing the zero bytes
+with a different byte and adding some more gadgets to the ROP chain that write
+zero to those stack locations.
 
 A question that comes up when looking at the stack diagram is "how do we
 know the addresses of these gadgets"? We will talk a bit more about this in


### PR DESCRIPTION
'NULL' is the idiom in C for describing a null _pointer_: something that is the size of a machine word and used to indicate the absence of an address of memory elsewhere.

The term for the zero _character_ code, used to terminate strings in C, is 'NUL' (as defined by ANSI X3.4).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/llsoftsec/llsoftsecbook/270)
<!-- Reviewable:end -->
