### PR TITLE
Test if Reviewable is disabled.

### DIFF
--- a/book.md
+++ b/book.md
@@ -37,7 +37,7 @@ header-includes:
   ```
 ...
 
-# Introduction
+# Introduction 
 
 Compilers, assemblers and similar tools generate all the binary code that
 processors execute.  It is no surprise then that these tools play a major role


### PR DESCRIPTION
We're finding that the reviewable.io review plugin for this project is making it harder for contributors to start contributing, as it does not allow to merge PRs until all reviewers involved have signed off on all review comments. Most reviewers or contributors don't know they have to explicitly sign off on all review comments before a PR can be merged; and it's an extra task that most of the time only adds friction without benefit. Therefore, I tried to disable the reviewable.io plugin. This PR is created just to test if indeed it has been disabled.