### PR TITLE
Add an index mechanism that works for all formats, not just latex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PANDOCFLAGS = \
 
 COMMONFILTERS = \
           --lua-filter theme/fignos.lua \
+          --lua-filter theme/index.lua \
           --citeproc
 
 .PHONY: all clean pdf html
@@ -33,6 +34,7 @@ img/%.pdf: img/%.svg
 	rsvg-convert -f pdf -o $@ $<
 svgimages := $(wildcard img/*.svg)
 pdfimages := $(patsubst %.svg,%.pdf,$(svgimages))
+commonfilters := theme/fignos.lua theme/index.lua
 
 clean:
 	rm -rf build default_pandoc_html_template default_pandoc_latex_template $(pdfimages)
@@ -48,7 +50,7 @@ build/book.html: book.md book.bib Makefile build theme/html/pandoc_template.html
 				 theme/html/convert_to_sidenote.lua \
 				 theme/html/markup_issue.lua \
 				 theme/html/markup_todo.lua \
-				 theme/fignos.lua \
+				 $(commonfilters) \
 				 theme/html/add_edit_to_headers.lua \
 				 build/default.css $(svgimages)
 	pandoc $< -t html \
@@ -86,7 +88,7 @@ build/LLSoftSecBook.epub: build/book.epub build
 build/book.tex: book.md book.bib Makefile build theme/tex/pandoc_template.tex \
 				theme/html/markup_issue.lua \
 				theme/html/markup_todo.lua \
-				theme/fignos.lua \
+				$(commonfilters) \
 				$(pdfimages)
 	pandoc $< -t latex \
 		--template theme/tex/pandoc_template.tex \

--- a/book.md
+++ b/book.md
@@ -140,10 +140,10 @@ defined [@Hicks2014] by explicitly listing their types, which include:
 
 Memory vulnerabilities are an important class of vulnerabilities that arise due
 to these types of errors, and they most commonly occur due to programming
-mistakes when using languages such as C/C++ \index{C}\index{C++}. These
-languages do not provide mechanisms to protect against memory access errors by
-default. An attacker can exploit such vulnerabilities to leak sensitive data or
-overwrite critical memory locations and gain control of the vulnerable program.
+mistakes when using languages such as [C]{.index}/[C++]{.index}. These languages
+do not provide mechanisms to protect against memory access errors by default. An
+attacker can exploit such vulnerabilities to leak sensitive data or overwrite
+critical memory locations and gain control of the vulnerable program.
 
 Memory vulnerabilities have a long history. The [Morris
 worm](https://en.wikipedia.org/wiki/Morris_worm) in 1988 was the first widely
@@ -171,7 +171,7 @@ vulnerabilities in mind and use techniques such as bounds checking and
 automatic memory management. If these languages promise to eliminate
 memory vulnerabilities, why are we still discussing this topic?
 
-On the one hand, C and C++ \index{C}\index{C++} remain very popular languages,
+On the one hand, [C]{.index} and [C++]{.index} remain very popular languages,
 particularly in the implementation of low-level software. On the other hand,
 programs written in memory safe languages can themselves be vulnerable to
 memory errors as a result of bugs in how they are implemented, e.g. a bug in
@@ -205,12 +205,11 @@ design effective mitigations, it's important to understand what these terms
 mean, how these primitives could be obtained by an attacker, and how they can
 be used.
 
-An _exploit primitive_\index{exploit primitive} is a mechanism that allows an
-attacker to perform a specific operation in the memory space of the
-victim program. This is done by providing specially crafted input to the
-victim program.
+An _[exploit primitive]{.index}_ is a mechanism that allows an attacker to
+perform a specific operation in the memory space of the victim program. This is
+done by providing specially crafted input to the victim program.
 
-A _write primitive_\index{write primitive} gives the attacker some level of
+A _[write primitive]{.index}_ gives the attacker some level of
 write access to the victim's memory space.  The value written and the address
 written to may be controlled by the attacker to various degrees. The primitive,
 for example, may allow:
@@ -228,11 +227,11 @@ The most powerful version of a write primitive is an _arbitrary write_
 primitive, where both the address and the value are fully controlled by the
 attacker.
 
-A _read primitive_\index{read primitive}, respectively, gives the attacker read
-access to the victim's memory space. The address of the memory location
-accessed will be controlled by the attacker to some degree, as for the write
-primitive. A particularly useful primitive is an _arbitrary read_ primitive, in
-which the address is fully controlled by the attacker.
+A _[read primitive]{.index}_, respectively, gives the attacker read access to
+the victim's memory space. The address of the memory location accessed will be
+controlled by the attacker to some degree, as for the write primitive. A
+particularly useful primitive is an _arbitrary read_ primitive, in which the
+address is fully controlled by the attacker.
 
 The effects of a write primitive are perhaps easier to understand, as it
 has obvious side-effects: a value is written to the victim program's memory.
@@ -240,23 +239,22 @@ But how can an attacker observe the result of a read primitive?
 
 This depends on whether the attack is interactive or non-interactive [@Hu2016].
 
-* In an _interactive attack_\index{interactive attack}, the attacker gives
-  malicious input to the victim program. The malicious input causes the victim
-  program to perform the read the attacker instructed it to, and to output
-  the results of that read. This output could be any kind of output, for
-  example a network packet that the victim transmits. The attacker can observe
-  the result of the read primitive by looking at this output, for example
-  parsing this network packet. This process then repeats: the attacker sends
-  more malicious input to the victim, observes the output and prepares the next
-  input. You can see an example of this type of attack in
-  [@Beer2020], which describes a zero-click radio proximity exploit.
-* In a _non-interactive (one-shot) attack_\index{non-interactive (one-shot)
-  attack}, the attacker provides all malicious input to the victim program at
-  once. The malicious input triggers multiple primitives one after the other,
-  and the primitives are able to observe the effects of the preceding
-  operations through the victim program's state. The input could be, for
-  example, in the form of a JavaScript program [@Groß2020], or a PDF file
-  pretending to be a GIF [@Beer2021].
+* In an _[interactive attack]{.index}_, the attacker gives malicious input to
+  the victim program. The malicious input causes the victim program to perform
+  the read the attacker instructed it to, and to output the results of that
+  read. This output could be any kind of output, for example a network packet
+  that the victim transmits. The attacker can observe the result of the read
+  primitive by looking at this output, for example parsing this network packet.
+  This process then repeats: the attacker sends more malicious input to the
+  victim, observes the output and prepares the next input. You can see an
+  example of this type of attack in [@Beer2020], which describes a zero-click
+  radio proximity exploit.
+* In a _[non-interactive (one-shot) attack]{.index}_, the attacker provides all
+  malicious input to the victim program at once. The malicious input triggers
+  multiple primitives one after the other, and the primitives are able to
+  observe the effects of the preceding operations through the victim program's
+  state. The input could be, for example, in the form of a JavaScript program
+  [@Groß2020], or a PDF file pretending to be a GIF [@Beer2021].
 
 ::: TODO
 The references in this section describe complicated modern exploits.
@@ -334,11 +332,11 @@ achieve their goals?
 
 The ultimate goal of an attacker may vary: it may be, among other things,
 getting access to a system, leaking sensitive information or bringing down a
-service. Frequently, a first step towards these wider goals is arbitrary code
-execution\index{arbitrary code execution} within the victim process. We have
-already mentioned that the attacker will typically have arbitrary computation
-capabilities at this point, but arbitrary code execution also involves things
-like calling arbitrary library functions and performing system calls.
+service. Frequently, a first step towards these wider goals is [arbitrary code
+execution]{.index} within the victim process. We have already mentioned that the
+attacker will typically have arbitrary computation capabilities at this point,
+but arbitrary code execution also involves things like calling arbitrary library
+functions and performing system calls.
 
 Some examples of how the attacker may use the obtained primitives:
 
@@ -433,9 +431,9 @@ where the program resumes execution after returning from `main`.
 
 Before non-executable stacks were mainstream, a common way to exploit these
 vulnerabilities would be to use the overflow to simultaneously write
-shellcode[^shellcode]\index{shellcode} to the stack and overwrite the return
-address so that it points to the shellcode. [@AlephOne1996] is a classic
-example of this technique.
+[shellcode]{.index}[^shellcode] to the stack and overwrite the return address so
+that it points to the shellcode. [@AlephOne1996] is a classic example of this
+technique.
 
 [^shellcode]: A shellcode is a short instruction sequence that performs an
   action such as starting a shell on the victim machine.
@@ -491,7 +489,7 @@ even when the value is leaked.
 Many buffer overflow vulnerabilities result from the use of unsafe library
 functions, such as `gets`, or from the unsafe use of library functions such as
 `strcpy`. There is extensive literature on writing secure
-C/C++\index{C}\index{C++} code, for example [@Seacord2013] and [@Dowd2006]. A
+[C]{.index}/[C++]{.index} code, for example [@Seacord2013] and [@Dowd2006]. A
 different approach to limiting the effects of overflows is library function
 hardening, which aims to detect buffer overflows and terminate the program
 gracefully. This involves the introduction of feature macros like
@@ -515,10 +513,10 @@ can be statically determined (`-fsanitize=bounds`), as well as various other
 ## Code reuse attacks
 
 In the early days of memory vulnerability exploitation, attackers could simply
-place shellcode\index{shellcode} of their choice in executable memory and jump
-to it. As non-executable stack and heap became mainstream, attackers started to
-reuse code already present in an application's binary and linked libraries
-instead. A variety of different techniques to this effect came to light.
+place [shellcode]{.index} of their choice in executable memory and jump to it.
+As non-executable stack and heap became mainstream, attackers started to reuse
+code already present in an application's binary and linked libraries instead. A
+variety of different techniques to this effect came to light.
 
 The simplest of these techniques is return-to-libc [@Solar1997]. Instead of
 returning to shellcode that the attacker has injected, the return address is
@@ -532,17 +530,16 @@ to modify the address.
 Return-to-libc attacks restrict an attacker to whole library functions. While
 this can lead to powerful attacks, it has also been demonstrated that it is
 possible to achieve arbitrary computation by combining a number of short
-instruction sequences ending in indirect control transfer instructions, known
-as **gadgets**\index{gadget}. The indirect control transfer instructions make
-it easy for an attacker to execute gadgets one after another, by controlling the
-memory or register that provides each control transfer instruction's target.
+instruction sequences ending in indirect control transfer instructions, known as
+**[gadgets]{.index}**. The indirect control transfer instructions make it easy
+for an attacker to execute gadgets one after another, by controlling the memory
+or register that provides each control transfer instruction's target.
 
-In return-oriented programming (ROP)\index{return-oriented programming (ROP)}
-[@Shacham2007], each gadget performs a simple operation, for example setting a
-register, then pops a return address from the stack and returns to it. The
-attacker constructs a fake call stack (often called a ROP chain\index{ROP
-chain}) which ensures a number of gadgets are executed one after another, in
-order to perform a more complex operation.
+In [return-oriented programming (ROP)]{.index} [@Shacham2007], each gadget
+performs a simple operation, for example setting a register, then pops a return
+address from the stack and returns to it. The attacker constructs a fake call
+stack (often called a [ROP chain]{.index}) which ensures a number of gadgets are
+executed one after another, in order to perform a more complex operation.
 
 This will hopefully become more clear with an example: a ROP chain for AArch64
 Linux that starts a shell, by calling `execve` with `"/bin/sh"` as an argument.
@@ -617,8 +614,8 @@ We can achieve this by constructing the fake call stack shown in figure
 address of `gadget_x2` has replaced a saved return address that will be loaded
 and returned to in the future. As an alternative, an attacker could place this
 fake call stack somewhere else, for example on the heap, and use a primitive
-that changes the stack pointer's value instead. This is known as stack
-pivoting\index{stack pivoting}.
+that changes the stack pointer's value instead. This is known as [stack
+pivoting]{.index}.
 
 Note that this fake call stack contains zero bytes, even without considering
 the exact values of the various return addresses included. An overflow bug that
@@ -635,12 +632,12 @@ A question that comes up when looking at the stack diagram is "how do we
 know the addresses of these gadgets"? We will talk a bit more about this in
 the next section.
 
-ROP gadgets like the ones used here may be easy to identify by visual
-inspection of a disassembled binary, but it's common for attackers to use
-"gadget scanner"\index{gadget scanner} tools in order to discover large numbers
-of gadgets automatically. Such tools can also be useful to a compiler engineer
-working on a code reuse attack mitigation, as they can point out code sequences
-that should be protected and have been missed.
+ROP gadgets like the ones used here may be easy to identify by visual inspection
+of a disassembled binary, but it's common for attackers to use
+"[gadget scanner]{.index}" tools in order to discover large numbers of gadgets
+automatically. Such tools can also be useful to a compiler engineer working on a
+code reuse attack mitigation, as they can point out code sequences that should
+be protected and have been missed.
 
 Anything in executable memory can potentially be used as a ROP gadget, even if
 the compiler has not intended it to be code. This includes literal pools which
@@ -655,14 +652,13 @@ byte instructions `pop %rdi; ret` which is a useful ROP gadget.
 
 ### Jump-oriented programming
 
-Jump-oriented programming (JOP)\index{jump-oriented programming (JOP)}
-[@Bletsch2011] is a variation on ROP, where gadgets can also end in indirect
-branch instructions instead of return instructions.  The attacker chains a
-number of such gadgets through a dispatcher gadget\index{dispatcher gadget},
-which loads pointers one after another from an array of pointers, and branches
-to each one in return. The gadgets used must be set up so that they branch or
-return back to the dispatcher after they're done. This is demonstrated in
-figure @fig:jop.
+[Jump-oriented programming (JOP)]{.index} [@Bletsch2011] is a variation on ROP,
+where gadgets can also end in indirect branch instructions instead of return
+instructions. The attacker chains a number of such gadgets through a [dispatcher
+gadget]{.index}, which loads pointers one after another from an array of
+pointers, and branches to each one in return. The gadgets used must be set up so
+that they branch or return back to the dispatcher after they're done. This is
+demonstrated in figure @fig:jop.
 
 ![JOP example](img/jop){ width=50% #fig:jop }
 
@@ -689,13 +685,12 @@ dispatcher gadget.
 
 ### Counterfeit Object-oriented programming
 
-Counterfeit Object-oriented programming (COOP)\index{counterfeit object-oriented
-programming (COOP)} [@Schuster2015] is a code reuse technique that takes
-advantage of C++ \index{C++} virtual function calls. A COOP attack takes
-advantage of existing virtual functions and
+[Counterfeit Object-oriented programming (COOP)]{.index} [@Schuster2015] is a
+code reuse technique that takes advantage of [C++]{.index} virtual function
+calls. A COOP attack takes advantage of existing virtual functions and
 [vtables](https://en.wikipedia.org/wiki/Virtual_method_table), and creates fake
 objects pointing to these existing vtables. The virtual functions used as
-gadgets in the attack are called vfgadgets\index{vfgadget}. To chain vfgadgets
+gadgets in the attack are called [vfgadgets]{.index}. To chain vfgadgets
 together, the attacker uses a "main loop gadget", similar to JOP's dispatcher
 gadget, which is itself a virtual function that loops over a container of
 pointers to C++ objects and invokes a virtual function on these objects.
@@ -713,14 +708,14 @@ example in the previous section. [261]{.issue}
 ### Sigreturn-oriented programming { #sec:sigreturn-oriented-programming }
 
 One last example of a code reuse attack that is worth mentioning here is
-sigreturn-oriented programming (SROP)\index{sigreturn-oriented programming
-(SROP)} [@Bosman2014]. It is a special case of ROP where the attacker creates a
-fake signal handler frame and calls `sigreturn`. `sigreturn` is a system call
-on many UNIX-type systems which is normally called upon return from a signal
-handler, and restores the state of the process based on the state that has been
-saved on the signal handler's stack by the kernel previously, on entry to the
-signal handler.  The ability to fake a signal handler frame and call
-`sigreturn` gives an attacker a simple way to control the state of the program.
+[sigreturn-oriented programming (SROP)]{.index} [@Bosman2014]. It is a special
+case of ROP where the attacker creates a fake signal handler frame and calls
+`sigreturn`. `sigreturn` is a system call on many UNIX-type systems which is
+normally called upon return from a signal handler, and restores the state of the
+process based on the state that has been saved on the signal handler's stack by
+the kernel previously, on entry to the signal handler. The ability to fake a
+signal handler frame and call `sigreturn` gives an attacker a simple way to
+control the state of the program.
 
 ## Mitigations against code reuse attacks
 
@@ -742,17 +737,18 @@ mitigations that make it harder for an attacker to obtain these capabilities.
 
 The ability for an attacker to overwrite code pointers often boils down to the
 being able to overwrite them while they are stored in memory, rather than in
-machine registers\index{register}. Overwriting value in machine registers
-directly is often not possible. Attackers use memory
-vulnerabilities\index{memory vulnerability} to be able to overwrite pointers in
-memory. With that in mind, one could assume that code reuse mitigations are not
-necessary for programs written in memory-safe languages, as they should not have
-any memory vulnerabilities. However, most real-life programs written in
-memory-safe languages still contain at least portions of binary code written in
-unsafe languages. An attacker could obtain a write primitive in the unsafe
-portion of the program, and use it to overwrite code pointers in the memory-safe
-portion of the program. Therefore, mitigations against code reuse attacks are
-still relevant for programs written in memory-safe languages.
+machine [registers]{.index entry="register"}. Overwriting value in machine
+registers directly is often not possible. Attackers use [memory
+vulnerabilities]{.index entry="memory vulnerability"} to be able to overwrite
+pointers in memory. With that in mind, one could assume that code reuse
+mitigations are not necessary for programs written in memory-safe languages, as
+they should not have any memory vulnerabilities. However, most real-life
+programs written in memory-safe languages still contain at least portions of
+binary code written in unsafe languages. An attacker could obtain a write
+primitive in the unsafe portion of the program, and use it to overwrite code
+pointers in the memory-safe portion of the program. Therefore, mitigations
+against code reuse attacks are still relevant for programs written in
+memory-safe languages.
 
 Another reason that attackers could obtain write primitives in memory-safe
 programs is due to bugs in the compiler or the runtime. This is especially true
@@ -761,8 +757,8 @@ details.
 
 ### ASLR
 
-[Address space layout randomization
-(ASLR)](https://en.wikipedia.org/wiki/Address_space_layout_randomization)\index{ASLR}
+[[Address space layout randomization
+(ASLR)]{.index}](https://en.wikipedia.org/wiki/Address_space_layout_randomization)
 makes this more difficult by randomizing the positions of the memory areas
 containing the executable, the loaded libraries, the stack and the heap. ASLR
 requires code to be position-independent. Given enough entropy, the chance that
@@ -772,7 +768,7 @@ successful attack will be greatly reduced.
 Does this mean that code reuse attacks have been made redundant by ASLR?
 Unfortunately, this is not the case. There are various ways in which an
 attacker can discover the memory layout of the victim program.  This is often
-referred to as an "info leak"\index{info leak} [@Serna2012].
+referred to as an "[info leak]{.index}" [@Serna2012].
 
 Since we can not exclude code reuse attacks solely by making addresses hard to
 guess, we need to also consider mitigations that prevent attackers from
@@ -784,13 +780,13 @@ need something more.
 
 ### Control-flow Integrity (CFI)
 
-[Control-flow integrity
-(CFI)](https://en.wikipedia.org/wiki/Control-flow_integrity)\index{CFI} is a
+[[Control-flow integrity
+(CFI)]{.index}](https://en.wikipedia.org/wiki/Control-flow_integrity) is a
 family of mitigations that aim to preserve the intended control flow of a
 program. This is done by restricting the possible targets of indirect branches
-and returns.  A scheme that protects indirect jumps and calls is referred to as
-forward-edge CFI\index{forward-edge CFI}, whereas a scheme that protects
-returns is said to implement backward-edge CFI\index{backward-edge CFI}.
+and returns. A scheme that protects indirect jumps and calls is referred to as
+[forward-edge CFI]{.index}, whereas a scheme that protects returns is said to
+implement [backward-edge CFI]{.index}.
 
 Ideally, a CFI scheme would not allow any control flow transfers that don't
 occur in a correct program execution. However, different schemes have varying
@@ -799,12 +795,12 @@ classes, with targets in each class treated as equivalent for security purpose.
 A branch is permitted to transfer control to any member of its intended target
 class.
 
-CFI schemes are sometimes classified as coarse-grained\index{coarse-grained
-CFI} or fine-grained\index{fine-grained CFI}. A coarse-grained
-CFI scheme is one that uses a small number of large equivalence classes,
-whereas a fine-grained scheme uses a larger number of smaller classes, so that
-the possible branch targets from a given location are more restricted (perhaps
-at a greater performance cost).
+CFI schemes are sometimes classified as [coarse-grained]{.index
+entry="coarse-grained CFI"} or [fine-grained]{.index entry="fine-grained CFI"}.
+A coarse-grained CFI scheme is one that uses a small number of large equivalence
+classes, whereas a fine-grained scheme uses a larger number of smaller classes,
+so that the possible branch targets from a given location are more restricted
+(perhaps at a greater performance cost).
 
 For example, a CFI scheme that allows an indirect function call to continue the
 execution at the start of any function would be considered coarse-grained. If
@@ -860,16 +856,17 @@ widely used in production. This book focuses mostly on the deployed CFI schemes.
 ##### Protecting (forward) indirect function calls
 
 In practice, most in-production CFI schemes harden indirect function calls by
-partitioning all functions present in the program into equivalence
-classes\index{equivalence class}. Each function is assigned a single
+partitioning all functions present in the program into [equivalence
+classes]{.index entry="equivalence class"}. Each function is assigned a single
 equivalence class.
 
 For C code, most CFI schemes either put all functions into a single equivalence
-class, or partition functions based on their signature\index{function signature}.
+class, or partition functions based on their [signature]{.index entry="function
+signature"}.
 
-For example, arm64e\index{arm64e} and pauthabi\index{pauthabi} put all C
-functions in a single equivalence class see @McCall2019. Examples of CFI schemes
-that partition C functions based on their signature include
+For example, [arm64e]{.index} and [pauthabi]{.index} put all C functions in a
+single equivalence class see @McCall2019. Examples of CFI schemes that partition
+C functions based on their signature include
 [kcfi](https://reviews.llvm.org/D119296) and
 [clang cfi](https://clang.llvm.org/docs/ControlFlowIntegrityDesign.html#forward-edge-cfi-for-indirect-function-calls).
 
@@ -920,8 +917,8 @@ based on their signature.
 
 ##### Protecting (forward) virtual calls
 
-Many CFI schemes check that a C++ \index{C++} virtual function call happens on
-an object of the correct dynamic type. A few examples are: clang-cfi, arm64e,
+Many CFI schemes check that a [C++]{.index} virtual function call happens on an
+object of the correct dynamic type. A few examples are: clang-cfi, arm64e,
 pauthabi.
 
 ::: {.example caption="C++ virtual function call"}
@@ -964,16 +961,16 @@ less precise on the call `b->f()` above.
 
 Switch statements with many cases whose values are densely packed together are
 often implemented using a
-[jump table](https://en.wikipedia.org/wiki/Branch_table)\index{jump table},
-which is an array of pointers or offsets to the code for each case. Ultimately,
-the address to jump to is computed by loading from the jump table, and then an
-indirect jump to the computed address is performed. If an attacker can control
-the value used to index into the jump table, they can make the jump target point
-to a different address, leading to the attacker taking over the control flow.
+[[jump table]{.index}](https://en.wikipedia.org/wiki/Branch_table), which is an
+array of pointers or offsets to the code for each case. Ultimately, the address
+to jump to is computed by loading from the jump table, and then an indirect jump
+to the computed address is performed. If an attacker can control the value used
+to index into the jump table, they can make the jump target point to a different
+address, leading to the attacker taking over the control flow.
 
-Most CFI schemes do not protect against this, but arm64e\index{arm64e} and
-pauthabi\index{pauthabi} do, as explained in the example below.
-This is also explained in [@McCall2019, slide 39-40].
+Most CFI schemes do not protect against this, but [arm64e]{.index} and
+[pauthabi]{.index} do, as explained in the example below. This is also explained
+in [@McCall2019, slide 39-40].
 
 ::: {.example caption="jump table CFI hardening"}
 
@@ -1059,12 +1056,11 @@ lJTI0_0:
 
 When a function is called, the address of the instruction after the call
 instruction is stored in a register or on the stack. That address of the next
-instruction is called the "return address"\index{return address}. When the
-called function returns, it will use an instruction to branch to the return
-address. This is an indirect control flow, since the target of the branch isn't
-hard-coded in the instruction, but comes from a register or a memory location.
-If an attacker can change the value of the return address, they can redirect the
-control flow.
+instruction is called the "[return address]{.index}". When the called function
+returns, it will use an instruction to branch to the return address. This is an
+indirect control flow, since the target of the branch isn't hard-coded in the
+instruction, but comes from a register or a memory location. If an attacker can
+change the value of the return address, they can redirect the control flow.
 
 ::: {.example caption="Typical AArch64 call/return sequence"}
 
@@ -1095,12 +1091,13 @@ f:
 Most backward-edge CFI schemes add checks before executing the return
 instruction to verify that the return address hasn't been tampered with.
 
-Shadow stack\index{shadow stack} approaches store the return address on a second
-stack. Some shadow stack approaches also store the return address in the
-original location in the normal stack. In those, before the return is executed,
-it verifies that the return value on both the regular stack and the shadow stack
-are equal. All shadow stack approaches have mechanisms to make it hard to
-impossible for an attacker to overwrite the return address on the shadow stack.
+[Shadow stack]]{.index entry="shadow stack"} approaches store the return address
+on a second stack. Some shadow stack approaches also store the return address in
+the original location in the normal stack. In those, before the return is
+executed, it verifies that the return value on both the regular stack and the
+shadow stack are equal. All shadow stack approaches have mechanisms to make it
+hard to impossible for an attacker to overwrite the return address on the shadow
+stack.
 
 A software-only implementation is the clang shadow stack, which is explained in
 more detail in section @sec:clang-shadow-stack. Hardware-supported shadow stacks
@@ -1120,12 +1117,11 @@ memory, such as:
 
 - C++ co-routines are typically implemented using structures containing code
   pointers. Abusing these has recently been coined as
-  [Coroutine Frame-Oriented Programming(CFOP)](https://www.usenix.org/conference/usenixsecurity25/presentation/bajo)\index{Coroutine
-  Frame-Oriented Programming (CFOP)}.
-- Procedure Linkage Table (PLT)\index{Procedure Linkage Table (PLT)} and the
-  [Global Offset Table(GOT)](https://en.wikipedia.org/wiki/Global_Offset_Table)\index{Global
-  Offset Table (GOT)} often contain code pointers. One common way to protect
-  these from being overwritten by an attacker is to make these tables
+  [[Coroutine Frame-Oriented Programming (CFOP)]{.index}](https://www.usenix.org/conference/usenixsecurity25/presentation/bajo).
+- [Procedure Linkage Table (PLT)]{.index} and the
+  [[Global Offset Table(GOT)]{.index}](https://en.wikipedia.org/wiki/Global_Offset_Table)
+  often contain code pointers. One common way to protect these from being
+  overwritten by an attacker is to make these tables
   [read-only during program startup](https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro).
 - Signal handlers and signal handler frames contain code pointers, see @sec:sigreturn-oriented-programming for more details.
 [Should we list examples of indirect control flow from other languages too?]{.todo}
@@ -1179,14 +1175,14 @@ generated for different types of control-flow transfers are similar.
 
 ##### Clang Shadow Stack { #sec:clang-shadow-stack }
 
-Clang also implements a backward-edge CFI scheme known as [Shadow
-Stack](https://clang.llvm.org/docs/ShadowCallStack.html)\index{shadow stack}.
-In Clang's implementation, a separate stack is used for return addresses, which
+Clang also implements a backward-edge CFI scheme known as [[Shadow Stack]{.index
+entry="shadow stack"}](https://clang.llvm.org/docs/ShadowCallStack.html). In
+Clang's implementation, a separate stack is used for return addresses, which
 means that stack-based buffer overflows cannot be used to overwrite return
-addresses. The address of the shadow stack is randomized and kept in a
-dedicated register, with care taken so that it is never leaked, which means
-that an arbitrary write primitive cannot be used against the shadow stack
-unless its location is discovered through some other means.
+addresses. The address of the shadow stack is randomized and kept in a dedicated
+register, with care taken so that it is never leaked, which means that an
+arbitrary write primitive cannot be used against the shadow stack unless its
+location is discovered through some other means.
 
 As an example, when compiling with `-fsanitize=shadow-call-stack -ffixed-x18`
 [^shadow-stack-flags], the code generated for the `main` function from the
@@ -1224,18 +1220,17 @@ CFI implementations. A hardware-based implementation has the potential to offer
 improved protection and performance compared to an equivalent software-only CFI
 scheme.
 
-One such example is Pointer Authentication\index{Pointer Authentication}
-[@Rutland2017], an Armv8.3 feature, supported only in AArch64 state, that can
-be used to mitigate code reuse attacks.
+One such example is [Pointer Authentication]{.index} [@Rutland2017], an Armv8.3
+feature, supported only in AArch64 state, that can be used to mitigate code
+reuse attacks.
 
 Pointer Authentication computes a pointer _signature_ for a given address,
-called a Pointer Authentication Code (PAC)\index{Pointer Authentication Code
-(PAC)}, see @fig:pauth-sign-auth. The PAC code is stored in the upper bits of
-the pointer which are otherwise unused.
+called a [Pointer Authentication Code (PAC)]{.index}, see @fig:pauth-sign-auth.
+The PAC code is stored in the upper bits of the pointer which are otherwise
+unused.
 
-A pointer with a PAC code in the upper bits is called a _signed
-pointer_\index{signed pointer}. A non-signed pointer is called a _raw
-pointer_\index{raw pointer}.
+A pointer with a PAC code in the upper bits is called a _[signed
+pointer]{.index}_. A non-signed pointer is called a _[raw pointer]{.index}_.
 
 The general idea behind Pointer Authentication is that attackers will try to
 overwrite a pointer in memory using a memory vulnerability. Pointer
@@ -1255,7 +1250,7 @@ pointers, or more.
 An essential aspect of pointer authentication being useful is to make it hard
 for an attacker to construct the correct PAC that will pass authentication. To
 achieve that, next to the address, 2 other inputs are used to compute the PAC: a
-so-called key\index{key} and a modifier\index{modifier}:
+so-called [key]{.index} and a [modifier]{.index}:
 
 - The key is a secret value that is not directly accessible to software, so that
   an attacker cannot retrieve the key value. This makes it hard for an attacker
@@ -1272,9 +1267,8 @@ so-called key\index{key} and a modifier\index{modifier}:
 
   When an attacker successfully takes a signed pointer from one context and
   overwrites another pointer in another context with it, this is called a
-  pointer substitution attack\index{pointer substitution attack}. Using
-  different modifiers for different contexts makes pointer substitution attacks
-  harder.
+  [pointer substitution attack]{.index}. Using different modifiers for different
+  contexts makes pointer substitution attacks harder.
 
 ![AArch64 sign and authenticate operations to convert raw pointers to signed
  pointers and vice versa](img/pauth_sign_auth){width=100% #fig:pauth-sign-auth }
@@ -1359,8 +1353,8 @@ for a given address and modifier, and is restricted to guessing it.
 The probability of success when guessing a PAC depends on the exact number of
 PAC bits available in a given system configuration.
 
-The authenticated pointers are vulnerable to pointer substitution
-attacks\index{pointer substitution attack}, where a pointer that has been signed
+The authenticated pointers are vulnerable to [pointer substitution
+attacks]{.index}, where a pointer that has been signed
 with a given modifier is replaced with a different pointer that has also been
 signed with the same modifier. In the `pac-ret` scheme, this is mitigated by
 using the stack pointer as the modifier, which limits reuse of signed return
@@ -1382,15 +1376,14 @@ implementing more general memory safety measures, beyond CFI.
 
 ##### BTI and other coarse-grained CFI schemes { #sec:bti }
 
-[Branch Target Identification
-(BTI)](https://developer.arm.com/documentation/102433/0100/Jump-oriented-programming?lang=en)
-\index{BTI}, introduced in Armv8.5, offers coarse-grained forward-edge
-protection. With BTI, the locations that are targets of indirect branches have
-to be marked with a new instruction, `BTI`. There are four different types of
-BTI instructions that permit different types of indirect branches (indirect
-jump, indirect call, both, or none). An indirect branch to a non-BTI
-instruction or the wrong type of BTI instruction will raise a Branch Target
-Exception.
+[[Branch Target Identification
+(BTI)]{.index}](https://developer.arm.com/documentation/102433/0100/Jump-oriented-programming?lang=en),
+introduced in Armv8.5, offers coarse-grained forward-edge protection. With BTI,
+the locations that are targets of indirect branches have to be marked with a new
+instruction, `BTI`. There are four different types of BTI instructions that
+permit different types of indirect branches (indirect jump, indirect call, both,
+or none). An indirect branch to a non-BTI instruction or the wrong type of BTI
+instruction will raise a Branch Target Exception.
 
 Both Clang and GCC support generating BTI instructions, with the
 `-mbranch-protection=bti` flag, or, to enable both BTI and return address
@@ -1426,14 +1419,13 @@ the next section.
 ## Non-control data attacks
 
 In the previous sections, we have focused on subverting control flow by
-overwriting control data\index{control data}, which are used to change the
-value of the program counter, such as return addresses and function pointers.
-Since these types of attacks are prominent, many mitigations have been designed
-with the goal of maintaining control-flow integrity. Non-control data
-attacks\index{non-control data attacks}, also known as data-only
-attacks\index{data-only attacks}, can completely bypass these mitigations,
-since the data they modify is not the control data that these mitigations
-protect.
+overwriting [control data]{.index}, which are used to change the value of the
+program counter, such as return addresses and function pointers. Since these
+types of attacks are prominent, many mitigations have been designed with the
+goal of maintaining control-flow integrity. [Non-control data attacks]{.index}
+entry="non-control data attacks"}, also known as [data-only attacks]{.index},
+can completely bypass these mitigations, since the data they modify is not the
+control data that these mitigations protect.
 
 Non-control data attacks can range from very simple attacks targeting a single
 piece of data to very elaborate attacks with very high expressiveness
@@ -1538,48 +1530,48 @@ memory errors.
 We have so far discussed how languages that are [not memory
 safe](#a-bit-of-background-on-memory-vulnerabilities), like C and C++, are
 vulnerable to memory errors and therefore exploitation.  In this section, we
-will discuss tools that are available to C/C++ \index{C}\index{C++}programmers
+will discuss tools that are available to [C]{.index}/[C++]{.index} programmers
 to help them detect vulnerabilities that can lead to memory errors.
 
 ### Sanitizers
 
-Sanitizers \index{sanitizers} are tools that detect bugs during program
-execution. Sanitizers usually have two components: a compiler instrumentation
-part that introduces the new checks, and a runtime library part. They are often
-too expensive to run in production mode, as they tend to increase execution
-time and memory usage. They are commonly used during testing of an application,
-frequently in combination with fuzzers\index{fuzzing}[^fuzzing].
+[Sanitizers]{.index entry="sanitizers"} are tools that detect bugs during
+program execution. Sanitizers usually have two components: a compiler
+instrumentation part that introduces the new checks, and a runtime library part.
+They are often too expensive to run in production mode, as they tend to increase
+execution time and memory usage. They are commonly used during testing of an
+application, frequently in combination with [fuzzers]{.index
+entry="fuzzing"}[^fuzzing].
 
-[^fuzzing]: [Fuzzing](https://en.wikipedia.org/wiki/Fuzzing) \index{fuzzing} is
-a powerful testing technique that relies on automatically generating large
-amounts of random inputs to the program under test.
+[^fuzzing]: [[Fuzzing]{.index
+entry="fuzzing"}](https://en.wikipedia.org/wiki/Fuzzing) is a powerful testing
+technique that relies on automatically generating large amounts of random inputs
+to the program under test.
 
-A very popular sanitizer is [Address
-Sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
-(ASan)\index{AddressSanitizer (ASan)}. It aims to detect various memory errors.
-These include out-of-bounds accesses, use-after-free, double-free and invalid
-free[^LeakSanitizer]. There are Address Sanitizer implementations for both GCC
-\index{GCC} and Clang\index{Clang}, but we will focus on the Clang
-implementation here.
+A very popular sanitizer is [[Address Sanitizer
+(ASan)]{.index}](https://clang.llvm.org/docs/AddressSanitizer.html). It aims to
+detect various memory errors. These include out-of-bounds accesses,
+use-after-free, double-free and invalid free[^LeakSanitizer]. There are Address
+Sanitizer implementations for both [GCC]{.index} and [Clang]{.index}, but we
+will focus on the Clang implementation here.
 
-[^LeakSanitizer]: ASan also includes a [memory leak
-detector](https://clang.llvm.org/docs/LeakSanitizer.html)
-\index{LeakSanitizer}.
+[^LeakSanitizer]: ASan also includes a [[memory leak detector]{.index
+entry="LeakSanitizer"}](https://clang.llvm.org/docs/LeakSanitizer.html).
 
-ASan uses shadow memory\index{shadow memory} to keep track of the state of the
-application's memory.  Each byte of shadow memory records information on 8
-bytes of the application's memory. It represents how many of the 8 bytes are
+ASan uses [shadow memory]{.index} to keep track of the state of the
+application's memory. Each byte of shadow memory records information on 8 bytes
+of the application's memory. It represents how many of the 8 bytes are
 addressable. When none of the bytes are addressable, it encodes additional
-details (whether the 8 bytes are out-of-bounds stack, out-of-bounds heap,
-freed memory, and so on).  Requiring one byte of shadow memory for every 8
-bytes of application memory means that ASan needs to reserve one-eighth of the
+details (whether the 8 bytes are out-of-bounds stack, out-of-bounds heap, freed
+memory, and so on). Requiring one byte of shadow memory for every 8 bytes of
+application memory means that ASan needs to reserve one-eighth of the
 application's virtual address space [@Serebryany2012]. Shadow memory is
 allocated in one contiguous chunk, which keeps mapping application memory to
 shadow memory simple.
 
 ASan's runtime library replaces memory allocation functions like
-`malloc`\index{malloc} and `free`\index{free} with its own specialized
-versions. `malloc` introduces redzones\index{redzone} before and after each
+[`malloc`]{.index} and [`free`]{.index} with its own specialized versions.
+`malloc` introduces [redzones]{.index entry="redzone"} before and after each
 allocation, which are marked as unaddressable. `free` marks the entire
 allocation as unaddressable and places it in quarantine, so that it doesn't get
 reallocated for a while (in a FIFO basis). This allows for detecting
@@ -1597,23 +1589,23 @@ and linking a program with the `-fsanitize=address` option. It is used in
 practice for testing [large
 projects](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/asan.md).
 There is a similar tool for dynamic memory error detection in the Linux kernel,
-[KASAN](https://www.kernel.org/doc/html/v5.0/dev-tools/kasan.html)\index{KASAN}.
+[[KASAN]{.index}](https://www.kernel.org/doc/html/v5.0/dev-tools/kasan.html).
 
 ASan's biggest drawback is its high runtime overhead and memory usage, due to
-the quarantine, redzones and shadow memory. [Hardware-assisted AddressSanitizer
-(HWASAN)](https://clang.llvm.org/docs/HardwareAssistedAddressSanitizerDesign.html)
-\index{HWASAN} works similarly to ASan, but with partial hardware assistance
-can result in lower memory overheads, at the cost of being less portable.
+the quarantine, redzones and shadow memory. [[Hardware-assisted AddressSanitizer
+(HWASAN)]{.index}](https://clang.llvm.org/docs/HardwareAssistedAddressSanitizerDesign.html)
+works similarly to ASan, but with partial hardware assistance can result in
+lower memory overheads, at the cost of being less portable.
 
-On AArch64\index{AArch64}, HWASAN uses Top-Byte Ignore (TBI)\index{Top-Byte
-Ignore (TBI)}. When TBI is enabled, the top byte of a pointer is ignored when
-performing a memory access, allowing software to use that top byte to store
-metadata, without affecting execution. Each allocation is aligned to 16 bytes
-and each 16-byte chunk of memory (called "granule") is randomly assigned an
-8-bit tag. The tag is stored in shadow memory and is also placed in the top
-byte of the pointer to the object. Memory loads and stores are then
-instrumented to check that the tag stored in the pointer matches the tag stored
-in memory, and report an error when a mismatch happens.
+On [AArch64]{.index}, HWASAN uses [Top-Byte Ignore (TBI)]{.index}. When TBI is
+enabled, the top byte of a pointer is ignored when performing a memory access,
+allowing software to use that top byte to store metadata, without affecting
+execution. Each allocation is aligned to 16 bytes and each 16-byte chunk of
+memory (called "granule") is randomly assigned an 8-bit tag. The tag is stored
+in shadow memory and is also placed in the top byte of the pointer to the
+object. Memory loads and stores are then instrumented to check that the tag
+stored in the pointer matches the tag stored in memory, and report an error when
+a mismatch happens.
 [Add diagram to demonstrate how HWASAN works [168]{.issue}]{.todo}
 
 For granules shorter than 16 bytes, the value stored in shadow memory is
@@ -1626,24 +1618,22 @@ granule.
 HWASAN is also easy to use, and simply requires compiling and linking an
 application with the `-fsanitize=hwaddress` flag.
 
-[MemTagSanitizer](https://llvm.org/docs/MemTagSanitizer.html)\index{MemTagSanitizer}
-goes one step further and uses the Armv8.5-A [Memory Tagging Extension
-(MTE)](https://developer.arm.com/documentation/102925/0100)\index{Memory
-Tagging Extension (MTE)}. With MTE, the tag checking is done automatically by
-hardware, and an exception is raised on mismatch. MTE's granule size is 16
-bits, whereas tags are 4-bit.
+[[MemTagSanitizer]{.index}](https://llvm.org/docs/MemTagSanitizer.html) goes one
+step further and uses the Armv8.5-A [[Memory Tagging Extension
+(MTE)]{.index}](https://developer.arm.com/documentation/102925/0100). With MTE,
+the tag checking is done automatically by hardware, and an exception is raised
+on mismatch. MTE's granule size is 16 bits, whereas tags are 4-bit.
 [Consider adding a whole section on MTE and its applications [169]{.issue}]{.todo}
 
-
-[UndefinedBehaviorSanitizer
-(UBSan)](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#ubsan-checks)
-\index{UBSan}detects undefined behavior during program execution, for example
-array out-of-bounds accesses for statically determined array bounds, null
-pointer dereference, signed integer overflow and various kinds of integer
-conversions that result in data loss. Although some of these checks are not
-directly related to memory errors, these kinds of errors can lead to incorrect
-pointer arithmetic, incorrect allocation sizes, and other issues that lead to
-memory errors, so it is important to detect them and address them.
+[[UndefinedBehaviorSanitizer
+(UBSan)]{.index}](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#ubsan-checks)
+detects undefined behavior during program execution, for example array
+out-of-bounds accesses for statically determined array bounds, null pointer
+dereference, signed integer overflow and various kinds of integer conversions
+that result in data loss. Although some of these checks are not directly related
+to memory errors, these kinds of errors can lead to incorrect pointer
+arithmetic, incorrect allocation sizes, and other issues that lead to memory
+errors, so it is important to detect them and address them.
 
 UBSan's documentation describes the full list of available checks. The majority
 of these checks are enabled with the `-fsanitize=undefined` flag, but
@@ -1653,11 +1643,11 @@ for checks related to integer conversions and arithmetic.
 There are many other sanitizers, more than can reasonably be covered in this
 section. For the interested reader, we list a few more:
 
- * [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html)\index{MemorySanitizer}:
-   detects uninitialized reads.
- * [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)\index{ThreadSanitizer}:
-   detects data races.
- * [GWP-ASan](https://llvm.org/docs/GwpAsan.html)\index{GWP-ASan}: detects
+- [[MemorySanitizer]{.index}](https://clang.llvm.org/docs/MemorySanitizer.html):
+  detects uninitialized reads.
+- [[ThreadSanitizer]{.index}](https://clang.llvm.org/docs/ThreadSanitizer.html):
+  detects data races.
+- [[GWP-ASan]{.index}](https://llvm.org/docs/GwpAsan.html): detects
    use-after-free and heap buffer overflows, with low overhead that makes it
    suitable for production environments. It performs checks only on a sample of
    allocations.
@@ -1673,12 +1663,12 @@ hardware-based, e.g. PAuth-based pointer integrity schemes, MTE etc
 
 Making sure that memory accesses happen within the bounds of each object's
 allocation is a very important part of memory safety. This is usually described
-with the term "spatial memory safety"\index{spatial memory safety}.
-Out-of-bounds accesses result in restricted read/write primitives\index{read
-primitive}\index{write primitive}[^restricted]. An attacker can often easily
-convert these into arbitrary read/write primitives. For example, this can be
-achieved by overwriting pointer fields in allocations following the object that
-was the target of the problematic memory access.
+with the term "[spatial memory safety]{.index}". Out-of-bounds accesses result
+in restricted [read/write primitives]{.index entry="read primitive"}[]{.index
+entry="write primitive"}[^restricted]. An attacker can often easily convert
+these into arbitrary read/write primitives. For example, this can be achieved by
+overwriting pointer fields in allocations following the object that was the
+target of the problematic memory access.
 
 [^restricted]: These primitives are restricted since they can only access a
 limited number of bytes past the end of the allocation.
@@ -1708,9 +1698,9 @@ performed.
 You may notice that there is a bit of overlap between the bounds checks
 introduced by `-fsanitize=bounds` and the Address Sanitizer. Although the scope
 of `-fsanitize=bounds` is restricted to statically sized arrays, it's
-interesting to note that it can still catch intra-object
-overflows\index{intra-object overflow} on array member accesses that the
-Address Sanitizer would not, because the access is still technically within the
+interesting to note that it can still catch [intra-object overflows]{.index
+entry="intra-object overflow"} on array member accesses that the Address
+Sanitizer would not, because the access is still technically within the
 allocation. For example, given the following code:
 ```
 struct foo {
@@ -1747,14 +1737,15 @@ member attribute, `element_count`. This attribute will apply to [flexible array
 members](https://en.wikipedia.org/wiki/Flexible_array_member) in structs,
 indicating another member of the struct that expresses the array's length.
 
-The [`-fbounds-safety`](https://discourse.llvm.org/t/rfc-enforcing-bounds-safety-in-c-fbounds-safety/70854)
+The
+[`-fbounds-safety`](https://discourse.llvm.org/t/rfc-enforcing-bounds-safety-in-c-fbounds-safety/70854)
 proposal goes a bit further, introducing a similar annotation that can be
 applied to pointers more generally. The proposal also aims to reduce the
 annotation burden placed on programmers by only requiring the annotations at
-[ABI](https://en.wikipedia.org/wiki/Application_binary_interface)\index{Application
-binary interface (ABI)} boundaries[^abi-boundary]. Local variables which do
-not cross ABI boundaries are implicitly converted to use wide pointers. These
-wide pointers store bounds information alongside the original pointer.
+[[Application Binary Interface (ABI)]{.index}](https://en.wikipedia.org/wiki/Application_binary_interface)
+boundaries[^abi-boundary]. Local variables which do not cross ABI boundaries are
+implicitly converted to use wide pointers. These wide pointers store bounds
+information alongside the original pointer.
 
 [^abi-boundary]: This refers to the interface between different binary modules,
 typically a user program and a system library. The ABI describes low-level
@@ -1782,12 +1773,13 @@ to use bounds checks for flexible arrays, as described in [@Cook2023].
 There are also hardware-based mitigations for violations of spatial memory
 safety. For example,
 [CHERI](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/) introduces
-_capabilities_\index{capability} to conventional Instruction Set Architectures.
-Capabilities combine a virtual address with metadata that describes its
-corresponding bounds and permissions. Capabilities cannot be forged, and can
-thus provide very strong guarantees. Arm has developed a prototype architecture
-that adapts CHERI, as well as a prototype SoC and development board, as part of
-the [Arm Morello Program](https://www.arm.com/architecture/cpu/morello).
+_[capabilities]{.index entry="capability"}_ to conventional Instruction Set
+Architectures. Capabilities combine a virtual address with metadata that
+describes its corresponding bounds and permissions. Capabilities cannot be
+forged, and can thus provide very strong guarantees. Arm has developed a
+prototype architecture that adapts CHERI, as well as a prototype SoC and
+development board, as part of the
+[Arm Morello Program](https://www.arm.com/architecture/cpu/morello).
 
 Of course, another approach to mitigating spatial memory safety vulnerabilities
 is using a language that has been designed with spatial memory safety in mind.
@@ -1815,16 +1807,16 @@ in practice before it is detected and fixed. This is, of course, assuming that
 the bug has not been [intentionally injected in the
 compiler](#supply-chain-attacks).
 
-Compiler bugs are an interesting source of security issues for [just-in-time
+Compiler bugs are an interesting source of security issues for [[just-in-time
 (JIT)](https://en.wikipedia.org/wiki/Just-in-time_compilation)
-compilers\index{JIT compilers}[^jit]. JIT compilation is often used in
-programs that receive source code as input during program execution, for
-example in web browsers, for executing JavaScript code included in web pages.
-In this context, the input to the JIT compiler comes from arbitrary websites
-and is therefore untrusted. Bugs in such JIT compilers can lead to compromise
-of the whole program (here, the browser) if a malicious input (e.g. coming from
-a malicious website) deliberately triggers miscompilation in order to break
-memory safety of the language being implemented.
+compilers]{.index}[^jit]. JIT compilation is often used in programs that receive
+source code as input during program execution, for example in web browsers, for
+executing JavaScript code included in web pages. In this context, the input to
+the JIT compiler comes from arbitrary websites and is therefore untrusted. Bugs
+in such JIT compilers can lead to compromise of the whole program (here, the
+browser) if a malicious input (e.g. coming from a malicious website)
+deliberately triggers miscompilation in order to break memory safety of the
+language being implemented.
 
 [^jit]: JIT compilers compile code during execution of a program, as opposed to
 the more traditional compilation where code is compiled before the program is
@@ -1834,17 +1826,16 @@ For this section, we focus on JavaScript, which is a dynamically typed,
 memory safe language, but the concerns we discuss also apply to other
 languages that are compiled dynamically.
 
-Without statically known types, in order to optimize JavaScript code,
-JavaScript engines resort to type profiling [@Pizlo2020], recording the types
-encountered while executing code. These types are then used during
-optimization, which speculates that the same types will be encountered in
-future runs of the code, and inserts checks to validate that these
-assumptions about types still hold. When a check fails, the optimized code is
-replaced by unoptimized code that can handle all types, a process known as
-deoptimization\index{deoptimization} or on-stack replacement
-(OSR)\index{on-stack replacement (OSR)}. Deoptimization makes sure that the
-state of the deoptimized function is recreated correctly for the point of
-execution where the type check failed.
+Without statically known types, in order to optimize JavaScript code, JavaScript
+engines resort to type profiling [@Pizlo2020], recording the types encountered
+while executing code. These types are then used during optimization, which
+speculates that the same types will be encountered in future runs of the code,
+and inserts checks to validate that these assumptions about types still hold.
+When a check fails, the optimized code is replaced by unoptimized code that can
+handle all types, a process known as [deoptimization]{.index} or [on-stack
+replacement (OSR)]{.index}. Deoptimization makes sure that the state of the
+deoptimized function is recreated correctly for the point of execution where the
+type check failed.
 
 For example, a function such as:
 ```
@@ -1882,16 +1873,14 @@ profiling, optimizing JavaScript compilers propagate the profiled types to
 dependent values. For example if a value `x` is expected to be a string, and we
 check this assumption, then `x + 1` will also be a string (and no additional
 check is needed in this case). In addition to simple type propagation, they
-usually perform range analysis\index{range analysis} to determine as precise a
-range for a value as possible, which is useful for bounds check
-elimination\index{bounds check elimination}.
+usually perform [range analysis]{.index} to determine as precise a range for a
+value as possible, which is useful for [bounds check elimination]{.index}.
 
-Bounds check elimination (BCE)\index{bounds check elimination} is a common
-optimization in languages that perform bounds checks on array accesses to
-ensure every accessed index is within the bounds of the array. BCE gets rid of
-bounds checks when they are proven to be redundant, e.g. when the array access
-uses a constant index that's known to be smaller than the length of the array.
-See
+[Bounds check elimination (BCE)]{.index} is a common optimization in languages
+that perform bounds checks on array accesses to ensure every accessed index is
+within the bounds of the array. BCE gets rid of bounds checks when they are
+proven to be redundant, e.g. when the array access uses a constant index that's
+known to be smaller than the length of the array. See
 [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length)
 for details on how out-of-bounds array accesses behave in JavaScript.
 
@@ -1934,7 +1923,7 @@ approaches, for example:
   1. Use fuzzing to discover compiler bugs. For JavaScript, a useful fuzzing tool
      is [Fuzzilli](https://github.com/googleprojectzero/fuzzilli).
   2. Be more conservative when it comes to error-prone compiler optimizations
-	 such as bounds check elimination. For example, the
+     such as bounds check elimination. For example, the
      [V8 JavaScript engine](https://v8.dev/) has introduced
      [hardening of bounds checks against typer bugs](https://bugs.chromium.org/p/v8/issues/detail?id=8806)
      [^bypass].
@@ -1943,8 +1932,7 @@ approaches, for example:
      read/write primitives on top of the initial limited primitives that bugs
      provide. For example, for 64-bit architectures, V8 implements a
      [sandbox](https://docs.google.com/document/d/1FM4fQmIhEqPG8uGp5o9A-mnPB5BOeScZYpkHjo0KKA8/edit),
-     built on top of [pointer compression](https://v8.dev/blog/pointer-compression)
-     \index{pointer compression}.
+     built on top of [[pointer compression]{.index}](https://v8.dev/blog/pointer-compression).
      With pointer compression, pointers are represented by 32-bit indices off a base
      pointer instead of as full 64-bit values. By making sure that all pointers
      inside the sandbox (where the JavaScript heap is located) are compressed,
@@ -1953,17 +1941,17 @@ approaches, for example:
      cannot be used to build an arbitrary read/write primitive by overwriting
      pointer values.
   4. Preventing code memory from being executable and writable at the same time
-     is also desirable. This is known as [W^X](https://en.wikipedia.org/wiki/W%5EX)
-     \index{W\^{}X}.
-     A naive implementation of W^X that simply switches memory permissions
-     based on page tables temporarily is not enough to prevent attackers from
-     writing to code memory [@Song2015], when multiple threads are involved.
-     A more effective solution would use a separate compilation process, which
-     is the only process that has write access to the JIT's code memory.
-     Alternatively, some architectures provide special features that can
-     restrict page-based memory permissions from userspace, effectively
-     allowing permissions to be different for different threads. Such features
-     can also be of use in implementing W^X. For AArch64, this feature is called
+     is also desirable. This is known as
+     [[W^X]{.index}](https://en.wikipedia.org/wiki/W%5EX). A naive
+     implementation of W^X that simply switches memory permissions based on page
+     tables temporarily is not enough to prevent attackers from writing to code
+     memory [@Song2015], when multiple threads are involved. A more effective
+     solution would use a separate compilation process, which is the only
+     process that has write access to the JIT's code memory. Alternatively, some
+     architectures provide special features that can restrict page-based memory
+     permissions from userspace, effectively allowing permissions to be
+     different for different threads. Such features can also be of use in
+     implementing W^X. For AArch64, this feature is called
      [permission overlays](https://developer.arm.com/documentation/102376/0200/Permission-indirection-and-permission-overlay-extensions).
 
 [^bypass]: This naturally leads to attempts to bypass the hardening too
@@ -1980,29 +1968,27 @@ Side-channels and covert channels are communication channels between two
 entities in a system, where the entities should not be able to communicate that
 way.
 
-A **covert channel**\index{covert channel} is a channel where both entities
-intend to communicate. A **side-channel**\index{side-channel} is a channel where
-one entity is the victim of an attack using the channel.
+A **[covert channel]{.index}** is a channel where both entities intend to
+communicate. A **[side-channel]{.index}** is a channel where one entity is the
+victim of an attack using the channel.
 
 The difference between a covert channel and a side-channel is whether both
 entities intend to communicate. In a side-channel attack, the entity not
-intending to communicate is called the **victim**\index{victim}. The other
-entity is sometimes called the **spy**\index{spy}.
+intending to communicate is called the **[victim]{.index}**. The other entity is
+sometimes called the **[spy]{.index}**.
 
 As we focus on attacks in this book, we'll mostly use the term side-channels
 in the rest of this chapter.
 
 The next few sections describe a variety of side-channels. Each section focusses
-on leakage through a specific so-called micro-architectural
-aspect\index{micro-architectural}, such as execution time, cache state or branch
-predictor state.
+on leakage through a specific so-called [micro-architectural]{.index} aspect,
+such as execution time, cache state or branch predictor state.
 
 ## Timing side-channels
 
 An implementation of a cryptographic algorithm can leak information about the
 data it processes if its run time is influenced by the value of the processed
-data. Attacks making use of this are called timing attacks\index{timing
-attacks}.
+data. Attacks making use of this are called [timing attacks]{.index}.
 
 The main mitigation against such attacks consists of carefully implementing the
 algorithm such that the execution time remains independent of the processed
@@ -2054,10 +2040,11 @@ also need to keep cache side-channel attacks in mind, which are discussed in the
 
 ## Cache side-channels
 
-[Caches](https://en.wikipedia.org/wiki/Cache_(computing))\index{cache} are used
-in almost every computing system. They are small memories that are much faster
-than the main memory. They automatically keep the most frequently used data, so
-that the average memory access time improves.
+[[Caches]{.index
+entry="cache"}](https://en.wikipedia.org/wiki/Cache_(computing)) are used in
+almost every computing system. They are small memories that are much faster than
+the main memory. They automatically keep the most frequently used data, so that
+the average memory access time improves.
 
 When processes share a cache, various techniques exist to establish a covert
 communication channel. These let the processes communicate through memory
@@ -2081,15 +2068,17 @@ executed read or write instruction.
 On every read and write instruction, the cache micro-architecture looks up if
 the data for the requested address happens to be present in the cache. If it is,
 the CPU can continue executing quickly; if not, dependent operations will have
-to wait until the data returns from the slower main memory. A typical access
-time is 3 to 5 CPU cycles for the fastest cache on a CPU versus hundreds of
-cycles for a main memory access.\index{memory access time} When data is present
-in the cache for a read or write, it is said to be a **cache hit**\index{cache
-hit}. Otherwise, it's called a **cache miss**\index{cache miss}.
+to wait until the data returns from the slower main memory. A typical [access
+time]{.index entry="memory access time"} is 3 to 5 CPU cycles for the fastest
+cache on a CPU versus hundreds of cycles for a main memory access. When data is
+present in the cache for a read or write, it is said to be a
+**[cache hit]{.index entry="cache!hit"}**. Otherwise, it's called a
+**[cache miss]{.index entry="cache!miss"}**.
 
-Most systems have multiple levels of cache\index{multi-level cache}, each with a
-different trade-off between cache size\index{cache size} and access
-time\index{cache access time}. Some typical characteristics might be:
+Most systems have [multiple levels of cache]{.index entry="cache!multi-level"},
+each with a different trade-off between [cache size]{.index entry="cache!size"}
+and [access time]{.index entry="cache!access time"}. Some typical
+characteristics might be:
 
 * L1 (level 1) cache, 32KB in size, with an access time of 4 cycles.
 * L2 cache, 256KB in size, with an access time of 10 cycles.
@@ -2102,38 +2091,42 @@ If data is not already present in a cache layer, it is typically stored there
 after it has been fetched from a slower cache level or main memory. This is
 often a good decision to make as there's a high likelihood the same address will
 be accessed by the program soon after. This high likelihood is known as the
-[principle of locality](https://en.wikipedia.org/wiki/Locality_of_reference)\index{principle
-of locality}\index{locality of reference}.
+[[principle of locality]{.index}](https://en.wikipedia.org/wiki/Locality_of_reference)][]{.index
+entry="locality of reference"}.
 
 Data is stored and transferred between cache levels in blocks of aligned memory.
-Such a block is called a **cache block**\index{cache block} or **cache
-line**\index{cache line}. Typical sizes are 32, 64 or 128 bytes per cache line.
+Such a block is called a **[cache block]{.index entry="cache!block"}** or
+**[cache line]{.index entry="cache!line"}**. Typical sizes are 32, 64 or 128
+bytes per cache line.
 
 When data that wasn't previously in the cache needs to be stored in the cache,
-room has to be made for it by removing, or **evicting**\index{cache eviction},
-some other address/data from it. How that choice gets made is decided by the
-[cache replacement policy](https://en.wikipedia.org/wiki/Cache_replacement_policies)\index{cache
-replacement policy}. Popular replacement algorithms are Least Recently Used
-(LRU)\index{LRU replacement policy}, Random\index{random replacement policy} and
-pseudo-LRU\index{pseudo-LRU replacement policy}. As the names suggest, LRU
-evicts the cache line that is least recently used; random picks a random cache
-line; and pseudo-LRU approximates choosing the least recently used line.
+room has to be made for it by removing, or **[evicting]{.index
+entry="cache!eviction"}**, some other address/data from it. How that choice gets
+made is decided by the [[cache replacement policy]{.index
+entry="cache!replacement
+policy"}](https://en.wikipedia.org/wiki/Cache_replacement_policies)]. Popular
+replacement algorithms are [Least Recently Used (LRU)]{.index
+entry="cache!LRU"}, [Random]{.index entry="cache!random replacement policy"} and
+[pseudo-LRU]{.index entry="cache!pseudo-LRU replacement policy"}. As the names
+suggest, LRU evicts the cache line that is least recently used; random picks a
+random cache line; and pseudo-LRU approximates choosing the least recently used
+line.
 
 If a cache line can be stored in all locations available in the cache, the cache
-is **fully-associative**\index{fully-associative cache}. Most caches are however
-not fully-associative, as it's too costly to implement. Instead, most caches are
-**set-associative**\index{set-associative cache}. In an N-way set-associative
-cache, a specific line can only be stored in one of N cache locations. For
-example, if a line can potentially be stored in one of 2 locations, the cache is
-said to be 2-way set-associative. If it can be stored in one of 4 locations,
-it's called 4-way set-associative, and so on. When an address can only be stored
-in one location in the cache, it is said to be
-**direct-mapped**\index{direct-mapped cache}, rather than 1-way set-associative.
-Typical organizations are direct-mapped, 2-way, 4-way, 8-way, 16-way or 32-way
-set-associative.
+is **[fully-associative]{.index entry="cache!fully-associative"}**. Most caches
+are however not fully-associative, as it's too costly to implement. Instead,
+most caches are **[set-associative]{.index entry="cache!set-associative"}**. In
+an N-way set-associative cache, a specific line can only be stored in one of N
+cache locations. For example, if a line can potentially be stored in one of 2
+locations, the cache is said to be 2-way set-associative. If it can be stored in
+one of 4 locations, it's called 4-way set-associative, and so on. When an
+address can only be stored in one location in the cache, it is said to be
+**[direct-mapped]{.index entry="cache!direct-mapped"}**, rather than 1-way
+set-associative. Typical organizations are direct-mapped, 2-way, 4-way, 8-way,
+16-way or 32-way set-associative.
 
 The set of cache locations that a particular cache line can be stored at is
-called a **cache set**\index{cache set}.
+called a **[cache set]{.index entry="cache!set"}**.
 
 #### Indexing in a set-associative cache
 
@@ -2162,7 +2155,7 @@ cache locations also works as described above. In fully-associative caches the
 number of cache sets is 1, so $S$=0.
 
 ::: TODO
-Also explain cache coherency \index{cache coherency}?
+Also explain cache coherency cache coherency?
 [173]{.issue}
 :::
 ::: TODO
@@ -2172,15 +2165,16 @@ Also say something about TLBs and prefetching?
 
 ### Operation of cache side-channels
 
-Cache side-channels typically work by the spy determining whether a memory
-access was a cache hit or a cache miss. From that information, the spy may be
-able to deduce bits of data that only the victim should have access to.
+[Cache side-channels]{.index entry="cache!side-channel"} typically work by the
+spy determining whether a memory access was a cache hit or a cache miss. From
+that information, the spy may be able to deduce bits of data that only the
+victim should have access to.
 
 Let's illustrate this by describing a few well-known cache side-channels:
 
 #### Flush+Reload
 
-In a so-called **Flush+Reload**\index{Flush+Reload} attack[@Yarom2014], the spy
+In a so-called **[Flush+Reload]{.index}** attack[@Yarom2014], the spy
 process shares memory with the victim process. The attack works in 3 steps:
 
   1. The Flush step: The spy flushes a specific address from the cache.
@@ -2205,8 +2199,8 @@ Flush+Reload attack can be used to leak GnuPG private keys.
 
 #### Prime+Probe
 
-In a **Prime+Probe** attack\index{Prime+Probe}, there is no need for memory to
-be shared between victim and spy. The attack works in 3 steps:
+In a **[Prime+Probe]{.index}** attack, there is no need for memory to be shared
+between victim and spy. The attack works in 3 steps:
 
   1. The Prime step: The spy fills one or more cache sets with its data, for
      example, by accessing data that maps to those cache sets.
@@ -2227,20 +2221,18 @@ similar 3-step pattern. [@Weber2021] describes this general pattern and uses it
 to automatically discover more side-channels that follow this 3-step pattern.
 They describe the general pattern as being:
 
-  1. An instruction sequence that resets the inner CPU state (**reset
-     sequence**).\index{reset sequence}
-  2. An instruction sequence that triggers a state change (**trigger
-     sequence**).\index{trigger sequence}
-  3. An instruction sequence that leaks the inner state (**measurement
-     sequence**).\index{measurement sequence}
+  1. An instruction sequence that resets the inner CPU state (**[reset
+     sequence]{.index}**).
+  2. An instruction sequence that triggers a state change (**[trigger
+     sequence]{.index}**).
+  3. An instruction sequence that leaks the inner state (**[measurement
+     sequence]{.index}**).
 
 Other cache-based side channel attacks following this general 3-step approach
-include: Flush+Flush\index{Flush+Flush}[@Gruss2016a],
-Flush+Prefetch\index{Flush+Prefetch}[@Gruss2016],
-Evict+Reload\index{Evict+Reload}[@Percival2005],
-Evict+Time\index{Evict+Time}[@Osvik2005],
-Reload+Refresh\index{Reload+Refresh}[@Briongos2020],
-Collide+Probe\index{Collide+Probe}[@Lipp2020], etc.
+include: [Flush+Flush]{.index}[@Gruss2016a],
+[Flush+Prefetch]{.index}[@Gruss2016], [Evict+Reload]{.index}[@Percival2005],
+[Evict+Time]{.index}[@Osvik2005], [Reload+Refresh]{.index}[@Briongos2020],
+[Collide+Probe]{.index}[@Lipp2020], etc.
 
 ### Mitigating cache side-channel attacks
 
@@ -2292,8 +2284,8 @@ proposed that aim to make attacks somewhat harder without losing too much system
 efficiency. [@Mushtaq2020] and [@Su2021] summarize dozens of proposals and
 implementations -- too many to try to describe them all here.
 
-One popular such mitigation is disabling [cpu
-multithreading](https://en.wikipedia.org/wiki/Multithreading_(computer_architecture))\index{multithreading}.
+One popular such mitigation is disabling [[cpu
+multithreading]{.index}](https://en.wikipedia.org/wiki/Multithreading_(computer_architecture)).
 For example,
 [Azure suggests that users who run untrusted code should consider disabling cpu multithreading](https://learn.microsoft.com/en-us/azure/virtual-machines/mitigate-se).
 [The linux kernel's core scheduling documentation](https://www.kernel.org/doc/Documentation/admin-guide/hw-vuln/core-scheduling.rst)
@@ -2303,9 +2295,9 @@ concurrently. It implements a scheduler that
 and only allows those to run simultaneously on the same core.
 
 One could argue that
-[site isolation](https://developer.chrome.com/blog/site-isolation/)\index{site
-isolation} as implemented in many web browsers is a mitigation that also falls
-into this category. Site isolation is described in more detail in
+[[site isolation]{.index}](https://developer.chrome.com/blog/site-isolation/) as
+implemented in many web browsers is a mitigation that also falls into this
+category. Site isolation is described in more detail in
 [its own section](#site-isolation).
 
 #### Mitigations disabling the spy program to infer a cache status change in the victim program through its own cache status
@@ -2317,16 +2309,17 @@ into the timer also makes it harder to distinguish between a cache hit and cache
 miss. This is one of the mitigations in javascript engines against Spectre
 attacks. For more information see this
 [v8 blog post](https://v8.dev/blog/spectre) or this
-[Firefox documentation of the performance.now() method](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)\index{Spectre}.
+[Firefox documentation of the performance.now() method](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)[]{.index
+entry="Spectre"}.
 
 Note that this is not a perfect mitigation - there are often surprising ways
 that an attacker can get a fine-grained enough timer or use statistical methods
 to be able to detect the difference between a cache hit or miss. One extreme
-example is the NetSpectre\index{NetSpectre} attack [@Schwarz2019] where the
-difference between cache hit and cache miss is measured over a network, by
-statistically analyzing delays on network packet responses. Furthermore,
-[@Schwarz2017] demonstrates how to construct high-resolution timers in various
-indirect ways in all browsers that have removed explicit fine-grained timers.
+example is the [NetSpectre]{.index} attack [@Schwarz2019] where the difference
+between cache hit and cache miss is measured over a network, by statistically
+analyzing delays on network packet responses. Furthermore, [@Schwarz2017]
+demonstrates how to construct high-resolution timers in various indirect ways in
+all browsers that have removed explicit fine-grained timers.
 
 Another possibility is to clear the cache between times when the victim runs and
 the spy runs. This is probably going to incur quite a bit of performance
@@ -2337,30 +2330,30 @@ at the same time on 2 CPUs sharing a cache level.
 
 ### Branch predictors
 
-Most CPUs implement one or more
-[instruction pipelines](https://en.wikipedia.org/wiki/Instruction_pipelining).
-\index{pipeline}\index{instruction pipeline} In an instruction pipeline, the
-next instruction is started before the previous instruction has finished
-executing. When the previous instruction is a branch instruction, the next
-instruction that needs to be executed is only known when that branch instruction
-completes. However, waiting for the branch instruction to finish before starting
-the next instruction leads to a big performance
-loss.[^branch-prediction-performance] Therefore, most CPUs
-predict\index{predict} which instruction needs to be executed after a branch,
-before the branch instruction has completed. Correctly and quickly predicting
-the instruction after a branch instruction is so important for performance that
-most CPUs have multiple
-[branch predictors](https://en.wikipedia.org/wiki/Branch_predictor)\index{branch
-predictor}, such as:
+Most CPUs implement one or more [[instruction pipelines]{.index
+entry="instruction
+pipeline"}](https://en.wikipedia.org/wiki/Instruction_pipelining). []{.index
+entry="pipeline"} In an instruction pipeline, the next instruction is started
+before the previous instruction has finished executing. When the previous
+instruction is a branch instruction, the next instruction that needs to be
+executed is only known when that branch instruction completes. However, waiting
+for the branch instruction to finish before starting the next instruction leads
+to a big performance loss.[^branch-prediction-performance] Therefore, most CPUs
+[predict]{.index} which instruction needs to be executed after a branch, before
+the branch instruction has completed. Correctly and quickly predicting the
+instruction after a branch instruction is so important for performance that most
+CPUs have multiple [[branch predictors]{.index entry="branch
+predictor"}](https://en.wikipedia.org/wiki/Branch_predictor), such as:
 
-- A predictor of the outcome of a conditional branch\index{conditional branch
-  direction predictor}: taken or not taken\index{taken branch}. The prediction
-  is typically history-based\index{history-based prediction}, i.e. based on the
-  outcome of this and other branches in the recent past.
-- A predictor of the target of a taken branch\index{branch target predictor},
-  i.e. the address of the next instruction after a taken branch.
-- A predictor that is specialized to predict the next instruction after a
-  function return instruction.\index{return address predictor}
+- A predictor of the outcome of a [conditional branch]{.index entry="conditional
+  branch direction predictor"}: [taken]{.index entry="taken branch"} or not
+  taken. The prediction is typically [history-based]{.index entry="history-based
+  prediction"}, i.e. based on the outcome of this and other branches in the
+  recent past.
+- A predictor of the [target of a taken branch]{.index entry="branch target
+  predictor"}, i.e. the address of the next instruction after a taken branch.
+- A predictor that is specialized to [predict the next instruction after a
+  function return instruction]{.index entry="return address predictor"}.
 
 [^branch-prediction-performance]: Over time, new CPU designs tend to support
 having more instructions in flight. [@Eyerman2009, section 4.2.3] suggests that
@@ -2375,15 +2368,15 @@ sections list a few examples, categorized per branch predictor component they
 target.
 
 #### Conditional branch direction predictor side-channel attacks
-\index{conditional branch direction predictor}
+[]{.index entry="conditional branch direction predictor"}
 
-Two examples are BranchScope [@Evtyushkin2018]\index{BranchScope} and
-BlueThunder [@Huo2019]\index{BlueThunder}. These attacks infer whether a branch
-is taken or not taken in a victim process. They do so by carefully making sure
-that a branch in the spy process uses the same branch predictor entry as the
-targeted branch in the victim process. By measuring whether the branch in the
-spy process gets predicted correctly, one can derive whether the branch in the
-victim process was taken or not.
+Two examples are [BranchScope]{.index} [@Evtyushkin2018] and
+[BlueThunder]{.index} [@Huo2019]. These attacks infer whether a branch is taken
+or not taken in a victim process. They do so by carefully making sure that a
+branch in the spy process uses the same branch predictor entry as the targeted
+branch in the victim process. By measuring whether the branch in the spy process
+gets predicted correctly, one can derive whether the branch in the victim
+process was taken or not.
 
 This can be thought of as somewhat akin to the [Prime+Probe cache-based side
 channel attacks](#primeprobe).
@@ -2391,41 +2384,41 @@ channel attacks](#primeprobe).
 When the outcome of a branch depends on a bit in a secret key, this can enable
 an attacker to derive the value of the secret key. These papers demonstrate
 deriving the secret key from implementations of specific cryptographic kernels.
-It can also be used to break [ASLR](#aslr)\index{ASLR}.
+It can also be used to break [[ASLR]{.index}](#aslr).
 
 #### Branch target predictor side-channel attacks
-\index{Branch target predictor}
+[]{.index entry="Branch target predictor"}
 
-Two examples are SBPA [@Aciicmez2007]\index{SBPA} and BranchShadow
-[@Lee2017]\index{BranchShadow}. These earlier attacks are based on making a
-branch in the spy process alias in the Branch Target Buffer (BTB\index{BTB})
-with a targeted branch in the victim process.
-They use methods such as timing difference, last branch
-records\index{last branch record}, instruction traces\index{instruction trace}
-or performance counters\index{performance counter} to measure whether the branch
-in the spy process caused a specific state change in the BTB.
+Two examples are [SBPA]{.index} [@Aciicmez2007] and [BranchShadow]{.index}
+[@Lee2017]. These earlier attacks are based on making a branch in the spy
+process alias in the [Branch Target Buffer (BTB)]{.index} with a targeted branch
+in the victim process. They use methods such as timing difference,
+[last branch records]{.index entry="last branch record"},
+[instruction traces]{.index entry="instruction trace"} or
+[performance counters]{.index entry="performance counter"} to measure whether
+the branch in the spy process caused a specific state change in the BTB.
 
 #### Return address predictor side-channel attacks
-\index{return address predictor}
+[]{.index entry="return address predictor"}
 
-One example is Hyper-Channel [@Bulygin2008]\index{Hyper-Channel}. In this case,
-a spy process invokes $N$ calls to fill up the return stack predictor. Then it
-lets the victim process execute. Then, the spy process can measure how many of
-its return stack entries have been removed from the Return Stack Buffer (RSB),
-by measuring the number of $N$ returns that get mis-predicted.
-If the number of calls in the victim
-process is dependent on secret information, this could leak it.
+One example is [Hyper-Channel]{.index} [@Bulygin2008]. In this case, a spy
+process invokes $N$ calls to fill up the return stack predictor. Then it lets
+the victim process execute. Then, the spy process can measure how many of its
+return stack entries have been removed from the Return Stack Buffer (RSB), by
+measuring the number of $N$ returns that get mis-predicted. If the number of
+calls in the victim process is dependent on secret information, this could leak
+it.
 
 The papers referred to above contain detailed explanations of how they set up
 the attack. All of these attacks use a general 3-step approach, similar to
 [cache side channels](#general-schema-for-cache-covert-channels):
 
-1. An instruction sequence that resets the branch predictor state (*reset
-   sequence*), run by the spy process.\index{reset sequence}
-2. An instruction sequence that triggers a branch predictor state change (*trigger
-   sequence*), run by the victim process.\index{trigger sequence}
-3. An instruction sequence that leaks the branch predictor state (*measurement
-   sequence*), run by the spy process\index{measurement sequence}
+1. An instruction sequence that resets the branch predictor state (*[reset
+   sequence]{.index}*), run by the spy process.
+2. An instruction sequence that triggers a branch predictor state change
+   (*[trigger sequence]{.index}*), run by the victim process.
+3. An instruction sequence that leaks the branch predictor state (*[measurement
+   sequence]{.index}*), run by the spy process.
 
 ### Mitigations
 
@@ -2464,27 +2457,27 @@ may affect the execution of that later instruction? In other words, there may be
 a **dependency** between an instruction that has not finished yet and a later
 instruction that the CPU also already started executing.
 
-There are various kinds of dependencies. One kind is **control
-dependencies**\index{control dependencies}, where whether the later instruction
-should be executed at all is dependent on the outcome of the earlier
-instruction. Other kinds are **true data dependencies**\index{true data
-dependency}, **anti-dependencies**\index{anti dependency} and **output
-dependencies**\index{output dependency}. More details about these kinds of
-dependencies can be found on
+There are various kinds of dependencies. One kind is **[control
+dependencies]{.index entry="control dependency"}**, where whether the later
+instruction should be executed at all is dependent on the outcome of the earlier
+instruction. Other kinds are **[true data dependencies]{.index entry="true data
+dependency"}**, **[anti-dependencies]{.index entry="data dependency"}** and
+**[output dependencies]{.index entry="output dependency"}**. More details about
+these kinds of dependencies can be found on
 [the wikipedia page about them](https://en.wikipedia.org/wiki/Data_dependency).
 
 CPUs overcome parallel execution limitations imposed by dependencies by making
-massive numbers of **predictions**\index{prediction}. For example, most CPUs
-predict whether conditional branches are taken or not, which is making a
-prediction on control dependencies. Another example is a CPU making a prediction
-on whether a load accesses the same memory address as a preceding store. If they
-do not access the same memory locations, the load can run in parallel with the
-store, as there is no data dependency between them. If they do access
-overlapping memory locations, there is a dependency and the store should
+massive numbers of **[predictions]{.index entry="prediction"}**. For example,
+most CPUs predict whether conditional branches are taken or not, which is making
+a prediction on control dependencies. Another example is a CPU making a
+prediction on whether a load accesses the same memory address as a preceding
+store. If they do not access the same memory locations, the load can run in
+parallel with the store, as there is no data dependency between them. If they do
+access overlapping memory locations, there is a dependency and the store should
 complete before the load can start executing.
 
-Starting to execute later instructions before all of their dependencies have been
-resolved, based on the predictions, is called **speculation**\index{speculation}.
+Starting to execute later instructions before all of their dependencies have
+been resolved, based on the predictions, is called **[speculation]{.index}**.
 
 Let's illustrate that with an example. The following C code
 
@@ -2535,10 +2528,10 @@ After discovering the branch was mis-predicted, the CPU would have to restore
 the correct, non-negated, value in register `x0`.
 
 Any instructions that are executed under so-called
-**mis-speculation**\index{mis-speculation}, are called **transient
-instructions**\index{transient instructions}.^[Transient instructions caused by
-incorrect branch-direction prediction have also been called **wrong-path
-instructions**\index{wrong-patch instructions} @Mutlu2004]
+**[mis-speculation]{.index}**, are called **[transient
+instructions]{.index}**.^[Transient instructions caused by incorrect
+branch-direction prediction have also been called **[wrong-path
+instructions]{.index}** @Mutlu2004]
 
 The paragraph above says "*the system state that affects the correct execution
 of the program, needs to be undone*". There is a lot of system state that does
@@ -2552,10 +2545,9 @@ influence the correct execution of a program; it merely influences its execution
 speed. Therefore, the effect of transient execution on the content of the cache
 is typically not undone when detecting mis-speculation.
 
-Sometimes, it is said that the **architectural effects**\index{architectural
-effects} of transient instructions need to be undone, but the
-**micro-architectural effects**\index{micro-architectural effects} do not need
-to be undone.
+Sometimes, it is said that the **[architectural effects]{.index}** of transient
+instructions need to be undone, but the
+**[micro-architectural effects]{.index}** do not need to be undone.
 
 The above explanation describes architectural effects as changes in system state
 that need to be undone after detecting mis-speculation. In reality, most systems
@@ -2567,18 +2559,18 @@ architectural state. [Could we find a good reference that explains
 micro-architectural versus architectural state in more detail? Is "Computer
 Architecture: A Quantitative Approach" the best reference available?]{.todo}
 
-**Faulting instructions**\index{faulting instructions} are instructions that
-generate an exception at run-time. Many instructions can generate an exception,
-and are hence **potentially faulting**. For example most load and store
-instructions generate an exception when the accessed address is not mapped.
-Since so many instructions can generate an exception, processors typically
-speculate that they do not generate an exception to enable more parallel
-execution.
+**[Faulting instructions]{.index entry="faulting instructions"}** are
+instructions that generate an exception at run-time. Many instructions can
+generate an exception, and are hence **potentially faulting**. For example most
+load and store instructions generate an exception when the accessed address is
+not mapped. Since so many instructions can generate an exception, processors
+typically speculate that they do not generate an exception to enable more
+parallel execution.
 
 When an instruction faults, the execution typically continues at another
 location. Any instructions later in the instruction stream which are
-speculatively executed before the fault is detected are also called **transient
-instructions**\index{transient instructions}.
+speculatively executed before the fault is detected are also called **[transient
+instructions]{.index}**.
 
 There is a kind of control dependency between every potentially-faulting
 instruction and the next one, as the next instruction to be executed depends on
@@ -2589,15 +2581,15 @@ after a misprediction, or transient instructions after a faulting instruction.
 
 ### Transient Execution Attacks
 
-**Transient execution attacks**\index{transient execution attacks} are a
-category of side-channel attacks that use the micro-architectural side-effects
-of transient execution as a side channel.
+**[Transient execution attacks]{.index entry="transient execution attacks"}**
+are a category of side-channel attacks that use the micro-architectural
+side-effects of transient execution as a side channel.
 
-The publication of the Spectre\index{Spectre} [@Kocher2019] and
-Meltdown\index{Meltdown} [@Lipp2018] attacks in 2018 started a period in which a
-large number of transient attacks were discovered and published. Most of them
-were given specific names, such as ZombieLoad, NetSpectre, LVI, Straight-line
-Speculation, etc. New variants continue to be published regularly.
+The publication of the [Spectre]{.index} [@Kocher2019] and [Meltdown]{.index}
+[@Lipp2018] attacks in 2018 started a period in which a large number of
+transient attacks were discovered and published. Most of them were given
+specific names, such as ZombieLoad, NetSpectre, LVI, Straight-line Speculation,
+etc. New variants continue to be published regularly.
 
 Covering each one of them in detail here would make the book overly lengthy, and
 may not necessarily help much with gaining a better insight in the common
@@ -2859,9 +2851,9 @@ There are also cases of security vulnerabilities that are not introduced by
 undefined behavior, the following piece of code is such an example. This was
 taken from the Linux kernel. Because the compiler sees that the pointer hash is
 never used after this point, it decides to delete the memset operation. We call
-this dead store optimization (DSO) \index{dead store optimization}. This has
-serious security implications because the intention of the programmer was to
-delete the `hash` information from memory.
+this [dead store optimization (DSO)]{.index}. This has serious security
+implications because the intention of the programmer was to delete the `hash`
+information from memory.
 
 ``` {.c}
 static void extract_buf(struct entropy_store *r, __u8 *out) {
@@ -2882,10 +2874,10 @@ void memzero_explicit(void *s, size_t count)
 }
 ```
 
-It still uses `memset` \index{memset} to delete the associated security
-sensitive data, but it also tries to eliminate the risk of DSO by using the
-OPTIMIZER\_HIDE\_VAR macro.  This, however, is not enough to fully eliminate
-dead stores [@MemZeroBarrier].  In case of using LTO, the buffer `s` is still
+It still uses [`memset`]{.index} to delete the associated security sensitive
+data, but it also tries to eliminate the risk of DSO by using the
+OPTIMIZER\_HIDE\_VAR macro. This, however, is not enough to fully eliminate dead
+stores [@MemZeroBarrier]. In case of using LTO, the buffer `s` is still
 vulnerable. For this reason, Linux maintainers added a further hardening
 mechanism by using a compiler barrier instead:
 
@@ -3329,7 +3321,8 @@ If after reading that, you think some specific aspects could be explained
 better, please do let us know by raising an
 [issue](https://github.com/llsoftsec/llsoftsecbook/issues/new).
 
-\printindex
+::: {#index}
+:::
 
 # References {-}
 ::: {#refs}

--- a/theme/fignos.lua
+++ b/theme/fignos.lua
@@ -177,11 +177,13 @@ function process_headers (header)
   if sec_label then
     headerlabel2counter[sec_label] = counter;
   end
+  -- also add attribute to header containing the section number
+  -- so that later pandoc filters can use it.
+  header.attr.attributes['section-number'] = section_counter_to_string(counter);
   return header;
 end
 
-function get_section_reference_text(label)
-  local section_number_array = headerlabel2counter[label]
+function section_counter_to_string(section_number_array)
   local ref_text = '';
   for i = 1, #section_number_array do
     ref_text = ref_text..section_number_array[i];
@@ -190,6 +192,11 @@ function get_section_reference_text(label)
     end
   end
   return ref_text;
+end
+
+function get_section_reference_text(label)
+  local section_number_array = headerlabel2counter[label]
+  return section_counter_to_string(section_number_array);
 end
 
 function get_link_text(citation, label)

--- a/theme/html/default.css
+++ b/theme/html/default.css
@@ -271,3 +271,31 @@ figure img + figcaption {
 /*.example > .caption::before {
   content: ": ";
 }*/
+
+.index-entry-list {
+  background-color:rgb(239, 239, 239);
+  column-count: 2;
+  column-gap: 1.5rem;
+}
+
+.index-entry {
+  display: block;
+}
+
+.index-entry-indentation {
+  display: inline-block;
+  width: 1em;
+}
+
+.index-entry-locator {
+  margin-left: auto;
+}
+
+.index-entry-locator a {
+  text-decoration: none;
+  color: #5B8FF9;
+}
+
+/*.index-entry-text::after {
+  content: ", "
+}*/

--- a/theme/index.lua
+++ b/theme/index.lua
@@ -1,0 +1,273 @@
+-- This lua pandoc filter adds index entries written in the pandoc document
+-- into an index where a div with id 'index' is present in the document.
+--
+-- Index entries in the pandoc document are written as spans, with class "index".
+-- For example:
+--   We are talking about a [concept]{.index} here.
+-- This filter will collect all such spans and create an index entry for it in the
+-- div with id 'index'.
+-- The index entries will be grouped by their text, and each entry will contain
+-- links to the spans that refer to that entry.
+-- For Latex output, it will use the default index mechanisms of latex: converting
+-- those spans to \index commands and using the \printindex command when replacing
+-- the div with id 'index'.
+-- For all other formats, it will create a div with class 'index-entry-list'
+-- containing the index entries.
+-- The entries will be sorted alphabetically.
+--
+-- By default, the text in the index will be the text of the span.
+-- If the span has an 'entry' attribute, that will be used instead.
+-- For example, the following will add an entry "idea" to the index:
+--   We are talking about a [concept]{.index entry="idea"} here.
+-- This filter also supports nested index entries, where the text of the index
+-- entry is separated by '!' characters. For example:
+--   We are talking about a [concept!idea]{.index} here.
+-- This will create an index entry "concept" with a subentry "idea".
+--
+-- This filter requires the fignos.lua filter to be run before it, as it relies
+-- on the fignos.lua filter to process the headers and add the section-number
+-- attribute to the headers.
+
+-- local logging = require 'theme/logging/logging'
+
+-- First, a few global variables and function to enable tracking the innermost
+-- header a span is in.
+-- This is needed to be able to add the section number to the index entries.
+span_id2innermost_header = {}
+last_header_seen = nil
+function record_headers(header)
+  --logging.warning('record_headers: ', header);
+  last_header_seen = header
+end
+
+function record_innermost_header_for_span(span)
+  assert(span.identifier, 'span should have an id');
+  assert(last_header_seen, 'last_header_seen should not be nil');
+  --logging.warning('recording last_header_seen for ', span);
+  span_id2innermost_header[span.identifier] = last_header_seen
+end
+
+-----
+
+used_ids2el = {}
+-- create a unique id based on a base string, where the base string is
+-- assumed not to be used by the user or any other script yet.
+function create_unique_id_for_el(base, el)
+  local counter = 1
+  local id = base .. '_' .. counter
+  while used_ids2el[id] do
+    id = base .. '_' .. counter
+    counter = counter + 1
+  end
+  used_ids2el[id] = el
+  return id
+end
+
+-----
+
+local function is_index_span(el)
+  -- Check if the span has class "index"
+  return el.classes:includes('index')
+end
+
+local function ensure_every_index_span_has_an_id(el)
+    if not is_index_span(el) then
+        return el
+    end
+    -- If the span does not have an identifier, create a unique one
+    if not el.identifier or el.identifier == '' then
+        el.identifier = create_unique_id_for_el('__index_entry', el)
+    end
+    return el
+end
+
+local function escape_latex(s)
+  -- Order matters: backslash first so we don't re-escape what we add.
+  s = s:gsub("\\", "\\textbackslash{}")
+  -- Characters LaTeX treats specially: # $ % & _ { }
+  s = s:gsub("([#%%$&_{}])", "\\%1")
+  -- Tilde and caret don't take a simple backslash escape in text mode.
+  s = s:gsub("~", "\\textasciitilde{}")
+  s = s:gsub("%^", "\\textasciicircum{}")
+  return s
+end
+
+-- index_entries is a table that maps the id of the span containing the index
+-- entry to the list of spans the index entry should refer to.
+-- It has 3 fields:
+--   . text, the text to be added to the index,
+--   . spans, the id's of the pandoc spans that should be referred to from this
+--     index entry,
+--   . subentries, a table that contains subentries for this index entry.
+--   The subentries are also tables with the same structure as index_entries.
+index_entries = {}
+
+local function find_index_entries_in_text(span)
+  if not is_index_span(span) then
+    return span
+  end
+  --logging.error('Found index entry: ' .. pandoc.utils.stringify(span.content))
+  local text = pandoc.utils.stringify(span.content)
+  -- if there is an "entry" attribute, use that as the text
+  if span.attributes and span.attributes['entry'] then
+    text = span.attributes['entry']
+  end
+    -- split the index entry text on '!' characters, as these are used to indicate
+  -- different levels of entry in the index.
+  local parts = {}
+  for part in string.gmatch(text, "[^!]+") do
+    -- remove leading and trailing whitespace from each part
+    part = part:match('^%s*(.-)%s*$')
+    -- if the part is empty, skip it
+    if part == '' then
+      goto continue
+    end
+    --logging.warning('adding part: ', part);
+    table.insert(parts, part)
+    ::continue::
+  end
+
+  local index_entry = index_entries
+  for i, part in ipairs(parts) do
+    if not index_entry[part] then
+      index_entry[part] = { text = part, spans = {}, subentries = {} }
+    end
+    -- if this is not the last part, we create a new index entry for the subentry
+    if i < #parts then
+      index_entry = index_entry[part].subentries
+    else
+      -- this is the last part, we add the span to the index entry
+      assert(i == #parts)
+      table.insert(index_entry[part].spans, span)
+    end
+  end
+
+  -- when output latex, just use latex's built-in index command
+  if FORMAT:match 'latex' then
+    local latex_index_entry = '\\index{'
+    for i, part in ipairs(parts) do
+      if i > 1 then
+        latex_index_entry = latex_index_entry .. '!'
+      end
+      latex_index_entry = latex_index_entry .. escape_latex(part)
+    end
+    latex_index_entry = latex_index_entry .. '}'
+    return { span,
+             pandoc.RawInline('latex', latex_index_entry)}
+  end
+  return span
+end
+
+local function get_index_entry_section_number(span)
+  -- Get the section number from the innermost header of the element
+  local header = span_id2innermost_header[span.identifier]
+  --logging.warning('innermost header: ', header);
+  if header and header.attr and header.attr.attributes then
+    local section_number = header.attr.attributes['section-number']
+    if section_number then
+      return section_number
+    end
+  end
+  return nil
+end
+
+local function create_index_entry(entry_text, spans, level)
+  -- Create a new span for the index entry
+  -- We build up that span with "inlines" bit by bit, in variable entry_inlines."
+  local entry_inlines = {}
+  for i = 1, level do
+    table.insert(entry_inlines,
+      pandoc.Span(pandoc.Str(""),
+                  { class = 'index-entry-indentation' }))
+  end
+  table.insert(entry_inlines,
+    pandoc.Span(entry_text, { class = 'index-entry-text' }))
+  -- Add links to the spans
+  local entry_links = {}
+  for i, span in ipairs(spans) do
+    -- Create a link to the span
+    local ref_text = get_index_entry_section_number(span)
+    if not ref_text then
+      ref_text = '(' .. pandoc.utils.stringify(i) .. ')'
+    end
+    local link = pandoc.Link(ref_text, '#' .. span.identifier)
+    if i > 0 then
+      table.insert(entry_links, pandoc.Space())
+    end
+    table.insert(entry_links, link)
+  end
+  table.insert(entry_inlines, pandoc.Space())
+  table.insert(entry_inlines,
+    pandoc.Span(entry_links, { class = 'index-entry-locator' }))
+  return pandoc.Span(entry_inlines, { class = 'index-entry' })
+end
+
+local function get_sorted_keys(t)
+  local keys = {}
+  for key in pairs(t) do
+    table.insert(keys, key)
+  end
+  table.sort(keys, function(a, b) return a:lower() < b:lower() end)
+  return keys
+end
+
+local function create_index_entry_hierarchy(entries, level)
+  -- Sort the index entries alphabetically
+  local entry_texts = get_sorted_keys(entries)
+  -- Create a list of index entries
+  local index_list = pandoc.List:new()
+  if #entry_texts == 0 then
+    -- If there are no entries, return an empty list
+    return index_list
+  end
+  -- When this is the first level, leave a blank line between index entries
+  -- starting with a different letter. It makes it easier to read an index
+  -- with lots of entries.
+  local first_letter_prev_entry = entry_texts[1]:sub(1, 1):lower()
+  for _, entry_text in ipairs(entry_texts) do
+    local first_letter = entry_text:sub(1, 1):lower()
+    if level == 0 and first_letter ~= first_letter_prev_entry then
+      index_list:insert(pandoc.Para({pandoc.Str('')}))
+      first_letter_prev_entry = first_letter
+    end
+    local sub_entries = entries[entry_text].subentries
+    local spans = entries[entry_text].spans
+    --logging.warning('Processing index entry: ', entry_text, ' with spans: ', spans);
+    local index_entry_span = create_index_entry(entry_text, spans, level)
+    index_list:insert(index_entry_span)
+    index_list:extend(create_index_entry_hierarchy(sub_entries, level + 1))
+  end
+  return index_list
+end
+
+local function process_divs(div)
+  -- Check if the div has an id of "index"
+  if div.identifier ~= 'index' then
+    return div
+  end
+  if FORMAT:match 'latex' then
+    return pandoc.RawBlock('latex', '\\printindex')
+  end
+  return {
+    pandoc.Header(1,
+      pandoc.Str('Index'),
+      { id = 'index-header', class = 'unnumbered' }),
+    pandoc.Div(
+      create_index_entry_hierarchy(index_entries, 0),
+      { class = 'index-entry-list' }),
+  }
+end
+
+-- We first make sure each index span has an id.
+-- Then, we record for each span the innermost header it is in.
+-- Then, we process all spans, to find all index entries in the text.
+-- Then we need to process all divs, to find the div with name "#index".
+return {
+  { Span = ensure_every_index_span_has_an_id },
+  {
+    traverse = 'topdown',
+    Header = record_headers,
+    Span = record_innermost_header_for_span,
+  },
+  { Span = find_index_entries_in_text },
+  { Div = process_divs } };


### PR DESCRIPTION
This commit makes that work by changing how we indicate index entries in the main text.
So far, we used '\index{_text_to_add_to_index_}' in the main text, which is a latex-specific mechanism. To make this more format-neutral, this patch changes this to using spans of class "index" to indicate that some text needs to be added to the index. In this patch, it has the following features. More features can be added in later patches, if it shows they would be useful.

- An index entry is added by putting the text that should be indexed in a span with class "index". It looks like this: ... An [exploit primitive]{.index} is a mechanism ... This will add "exploit primitive" to the index. Before this patch, this would be written as: ... An exploit primitive\index{exploit primitive} is a mechanism ...
- When you want the entry in the index to be different from the text in the span, use the "entry" attribute on the span. For example: ... CFI schemes are sometimes classified as [coarse-grained]{.index entry="coarse-grained CFI"} or [fine-grained]{.index entry="fine-grained CFI"}. ...
- If you want multi-level index entries, use the same character as in latex to indicate the different levels. For example: ... [cache invalidation]{.index entry="cache!invalidation"} ... will add a sub-entry "invalidation" under the main entry "cache" in the index.